### PR TITLE
fix keybinds working when typing in the recipe book in a vanilla container

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ One feature will be limited:
 - LOLCATS
 - Upside Down English
 - Brazilian Portuguese
+- Bulgarian
 
 ### License
 Roughly Enough Items was a fork of Almost Enough Items by ZenDarva until v2.0 rewrite. This fork is permitted under the MIT license.  

--- a/src/main/java/me/shedaniel/rei/RoughlyEnoughItemsCore.java
+++ b/src/main/java/me/shedaniel/rei/RoughlyEnoughItemsCore.java
@@ -11,6 +11,7 @@ import me.shedaniel.rei.client.ConfigManager;
 import me.shedaniel.rei.client.*;
 import me.shedaniel.rei.gui.ContainerScreenOverlay;
 import me.shedaniel.rei.listeners.CreativePlayerInventoryScreenHooks;
+import me.shedaniel.rei.listeners.RecipeBookGuiHooks;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
@@ -18,8 +19,13 @@ import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.ContainerScreen;
 import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.container.BlastFurnaceScreen;
+import net.minecraft.client.gui.container.CraftingTableScreen;
+import net.minecraft.client.gui.container.FurnaceScreen;
+import net.minecraft.client.gui.container.SmokerScreen;
 import net.minecraft.client.gui.ingame.CreativePlayerInventoryScreen;
 import net.minecraft.client.gui.ingame.PlayerInventoryScreen;
+import net.minecraft.client.gui.recipebook.RecipeBookGui;
 import net.minecraft.client.gui.widget.RecipeBookButtonWidget;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.item.ItemGroup;
@@ -29,6 +35,7 @@ import net.minecraft.util.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import javax.swing.*;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
@@ -213,8 +220,18 @@ public class RoughlyEnoughItemsCore implements ClientModInitializer {
         });
         ClothClientHooks.SCREEN_KEY_PRESSED.register((minecraftClient, screen, i, i1, i2) -> {
             if (screen instanceof CreativePlayerInventoryScreen && ((CreativePlayerInventoryScreenHooks) screen).rei_getSelectedTab() == ItemGroup.SEARCH.getIndex())
-                if (screen.getFocused() != null && screen.getFocused() instanceof TextFieldWidget && ((TextFieldWidget) screen.getFocused()).isFocused())
+                if (screen.getFocused() != null && screen.getFocused() instanceof TextFieldWidget)
                     return ActionResult.PASS;
+
+            if (
+                (screen instanceof PlayerInventoryScreen && ((RecipeBookGuiHooks) (((PlayerInventoryScreen) screen).getRecipeBookGui())).rei_getRecipeBookSearchField().isFocused()) ||
+                (screen instanceof FurnaceScreen && ((RecipeBookGuiHooks) (((FurnaceScreen) screen).getRecipeBookGui())).rei_getRecipeBookSearchField().isFocused()) ||
+                (screen instanceof SmokerScreen && ((RecipeBookGuiHooks) (((SmokerScreen) screen).getRecipeBookGui())).rei_getRecipeBookSearchField().isFocused()) ||
+                (screen instanceof BlastFurnaceScreen && ((RecipeBookGuiHooks) (((BlastFurnaceScreen) screen).getRecipeBookGui())).rei_getRecipeBookSearchField().isFocused()) ||
+                (screen instanceof CraftingTableScreen && ((RecipeBookGuiHooks) (((CraftingTableScreen) screen).getRecipeBookGui())).rei_getRecipeBookSearchField().isFocused())
+            )
+                return ActionResult.PASS;
+
             if (screen instanceof ContainerScreen)
                 if (ScreenHelper.getLastOverlay().keyPressed(i, i1, i2))
                     return ActionResult.SUCCESS;

--- a/src/main/java/me/shedaniel/rei/RoughlyEnoughItemsCore.java
+++ b/src/main/java/me/shedaniel/rei/RoughlyEnoughItemsCore.java
@@ -25,7 +25,6 @@ import net.minecraft.client.gui.container.FurnaceScreen;
 import net.minecraft.client.gui.container.SmokerScreen;
 import net.minecraft.client.gui.ingame.CreativePlayerInventoryScreen;
 import net.minecraft.client.gui.ingame.PlayerInventoryScreen;
-import net.minecraft.client.gui.recipebook.RecipeBookGui;
 import net.minecraft.client.gui.widget.RecipeBookButtonWidget;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.item.ItemGroup;
@@ -35,7 +34,6 @@ import net.minecraft.util.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import javax.swing.*;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/me/shedaniel/rei/client/ClientHelper.java
+++ b/src/main/java/me/shedaniel/rei/client/ClientHelper.java
@@ -40,7 +40,6 @@ public class ClientHelper implements ClientModInitializer {
     public static String getModFromItemStack(ItemStack stack) {
         if (!stack.isEmpty()) {
             Identifier location = Registry.ITEM.getId(stack.getItem());
-            assert location != null;
             String modid = location.getNamespace();
             if (modid.equalsIgnoreCase("minecraft"))
                 return "Minecraft";

--- a/src/main/java/me/shedaniel/rei/gui/ContainerScreenOverlay.java
+++ b/src/main/java/me/shedaniel/rei/gui/ContainerScreenOverlay.java
@@ -13,6 +13,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.audio.PositionedSoundInstance;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.*;
+import net.minecraft.client.gui.ingame.CreativePlayerInventoryScreen;
 import net.minecraft.client.render.GuiLighting;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.Window;
@@ -444,12 +445,15 @@ public class ContainerScreenOverlay extends AbstractParentElement implements Dra
     }
     
     @Override
-    public boolean keyPressed(int int_1, int int_2, int int_3) {
+    public boolean keyPressed(int keyCode, int int_2, int int_3) {
         if (ScreenHelper.isOverlayVisible())
             for(Element listener : widgets)
-                if (listener.keyPressed(int_1, int_2, int_3))
+                if (listener.keyPressed(keyCode, int_2, int_3))
                     return true;
-        if (ClientHelper.HIDE.matchesKey(int_1, int_2)) {
+
+
+
+        if (ClientHelper.HIDE.matchesKey(keyCode, int_2)) {
             ScreenHelper.toggleOverlayVisible();
             return true;
         }
@@ -460,9 +464,9 @@ public class ContainerScreenOverlay extends AbstractParentElement implements Dra
             if (ScreenHelper.getLastContainerScreenHooks().rei_getHoveredSlot() != null && !ScreenHelper.getLastContainerScreenHooks().rei_getHoveredSlot().getStack().isEmpty())
                 itemStack = ScreenHelper.getLastContainerScreenHooks().rei_getHoveredSlot().getStack();
         if (itemStack != null && !itemStack.isEmpty()) {
-            if (ClientHelper.RECIPE.matchesKey(int_1, int_2))
+            if (ClientHelper.RECIPE.matchesKey(keyCode, int_2))
                 return ClientHelper.executeRecipeKeyBind(itemStack);
-            else if (ClientHelper.USAGE.matchesKey(int_1, int_2))
+            else if (ClientHelper.USAGE.matchesKey(keyCode, int_2))
                 return ClientHelper.executeUsageKeyBind(itemStack);
         }
         return false;

--- a/src/main/java/me/shedaniel/rei/listeners/RecipeBookGuiHooks.java
+++ b/src/main/java/me/shedaniel/rei/listeners/RecipeBookGuiHooks.java
@@ -1,9 +1,12 @@
 package me.shedaniel.rei.listeners;
 
 import net.minecraft.client.gui.widget.RecipeBookGhostSlots;
+import net.minecraft.client.gui.widget.TextFieldWidget;
 
-public interface GhostSlotsHooks {
+public interface RecipeBookGuiHooks {
     
     RecipeBookGhostSlots rei_getGhostSlots();
-    
+
+    TextFieldWidget rei_getRecipeBookSearchField();
+
 }

--- a/src/main/java/me/shedaniel/rei/mixin/MixinRecipeBookGui.java
+++ b/src/main/java/me/shedaniel/rei/mixin/MixinRecipeBookGui.java
@@ -1,21 +1,29 @@
 package me.shedaniel.rei.mixin;
 
-import me.shedaniel.rei.listeners.GhostSlotsHooks;
+import me.shedaniel.rei.listeners.RecipeBookGuiHooks;
 import net.minecraft.client.gui.recipebook.RecipeBookGui;
 import net.minecraft.client.gui.widget.RecipeBookGhostSlots;
+import net.minecraft.client.gui.widget.TextFieldWidget;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(RecipeBookGui.class)
-public class MixinRecipeBookGui implements GhostSlotsHooks {
+public class MixinRecipeBookGui implements RecipeBookGuiHooks {
     
     @Shadow
     @Final
     protected RecipeBookGhostSlots ghostSlots;
+
+    @Shadow
+    private TextFieldWidget searchField;
     
     public RecipeBookGhostSlots rei_getGhostSlots() {
         return ghostSlots;
+    }
+
+    public TextFieldWidget rei_getRecipeBookSearchField() {
+        return searchField;
     }
     
 }

--- a/src/main/java/me/shedaniel/rei/plugin/DefaultPlugin.java
+++ b/src/main/java/me/shedaniel/rei/plugin/DefaultPlugin.java
@@ -5,7 +5,7 @@ import me.shedaniel.rei.RoughlyEnoughItemsCore;
 import me.shedaniel.rei.api.*;
 import me.shedaniel.rei.client.ScreenHelper;
 import me.shedaniel.rei.gui.RecipeViewingScreen;
-import me.shedaniel.rei.listeners.GhostSlotsHooks;
+import me.shedaniel.rei.listeners.RecipeBookGuiHooks;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.ContainerScreen;
 import net.minecraft.client.gui.Screen;
@@ -239,9 +239,9 @@ public class DefaultPlugin implements REIPlugin {
                 if (!recipe.getRecipe().isPresent())
                     return false;
                 if (screen.getClass().isAssignableFrom(CraftingTableScreen.class))
-                    ((GhostSlotsHooks) (((CraftingTableScreen) screen).getRecipeBookGui())).rei_getGhostSlots().reset();
+                    ((RecipeBookGuiHooks) (((CraftingTableScreen) screen).getRecipeBookGui())).rei_getGhostSlots().reset();
                 else if (screen.getClass().isAssignableFrom(PlayerInventoryScreen.class))
-                    ((GhostSlotsHooks) (((PlayerInventoryScreen) screen).getRecipeBookGui())).rei_getGhostSlots().reset();
+                    ((RecipeBookGuiHooks) (((PlayerInventoryScreen) screen).getRecipeBookGui())).rei_getGhostSlots().reset();
                 else
                     return false;
                 MinecraftClient.getInstance().interactionManager.clickRecipe(MinecraftClient.getInstance().player.container.syncId, (Recipe) recipe.getRecipe().get(), Screen.hasShiftDown());
@@ -264,7 +264,7 @@ public class DefaultPlugin implements REIPlugin {
                 if (!recipe.getRecipe().isPresent())
                     return false;
                 if (screen instanceof FurnaceScreen)
-                    ((GhostSlotsHooks) (((FurnaceScreen) screen).getRecipeBookGui())).rei_getGhostSlots().reset();
+                    ((RecipeBookGuiHooks) (((FurnaceScreen) screen).getRecipeBookGui())).rei_getGhostSlots().reset();
                 else
                     return false;
                 MinecraftClient.getInstance().interactionManager.clickRecipe(MinecraftClient.getInstance().player.container.syncId, (Recipe) recipe.getRecipe().get(), Screen.hasShiftDown());
@@ -287,7 +287,7 @@ public class DefaultPlugin implements REIPlugin {
                 if (!recipe.getRecipe().isPresent())
                     return false;
                 if (screen instanceof SmokerScreen)
-                    ((GhostSlotsHooks) (((SmokerScreen) screen).getRecipeBookGui())).rei_getGhostSlots().reset();
+                    ((RecipeBookGuiHooks) (((SmokerScreen) screen).getRecipeBookGui())).rei_getGhostSlots().reset();
                 else
                     return false;
                 MinecraftClient.getInstance().interactionManager.clickRecipe(MinecraftClient.getInstance().player.container.syncId, (Recipe) recipe.getRecipe().get(), Screen.hasShiftDown());
@@ -315,7 +315,7 @@ public class DefaultPlugin implements REIPlugin {
                 if (!recipe.getRecipe().isPresent())
                     return false;
                 if (screen instanceof BlastFurnaceScreen)
-                    ((GhostSlotsHooks) (((BlastFurnaceScreen) screen).getRecipeBookGui())).rei_getGhostSlots().reset();
+                    ((RecipeBookGuiHooks) (((BlastFurnaceScreen) screen).getRecipeBookGui())).rei_getGhostSlots().reset();
                 else
                     return false;
                 MinecraftClient.getInstance().interactionManager.clickRecipe(MinecraftClient.getInstance().player.container.syncId, (Recipe) recipe.getRecipe().get(), Screen.hasShiftDown());


### PR DESCRIPTION
also added Bulgarian to the README  
  
i've also fixed keybinds working in the creative search bar, which was supposed to be fixed but doesn't seem to have been (at least on my end)  
  
the "solution" for keybinds working in recipe books isn't perfect; it only works with vanilla containers (+ it's ugly), i think it might be better to have an event for typing in the recipe book which should be used for this, if possible