### PR TITLE
fixes #67

### DIFF
--- a/src/main/java/me/shedaniel/rei/gui/widget/ItemListOverlay.java
+++ b/src/main/java/me/shedaniel/rei/gui/widget/ItemListOverlay.java
@@ -94,12 +94,12 @@ public class ItemListOverlay extends Widget {
         int fitSlotsPerPage = getTotalFitSlotsPerPage(listArea.x, listArea.y, listArea);
         int j = page * fitSlotsPerPage;
         for(int i = 0; i < getFullTotalSlotsPerPage(); i++) {
+            j++;
             if (j >= currentDisplayed.size())
                 break;
             int x = startX + (i % width) * 18, y = startY + MathHelper.floor(i / width) * 18;
             if (!canBeFit(x, y, listArea))
                 continue;
-            j++;
             widgets.add(new ItemSlotWidget(x, y, Collections.singletonList(currentDisplayed.get(j)), false, true, true) {
                 @Override
                 protected void queueTooltip(ItemStack itemStack, float delta) {


### PR DESCRIPTION
The mod would crash from a `java.lang.IndexOutOfBoundsException` when at the last page of the item list

The issue was introduced by d7b09003852682c8c1562e0d73a9494cc54e7a6b

```java
        for(int i = 0; i < getFullTotalSlotsPerPage(); i++) {
            if (j >= currentDisplayed.size())
                break;
            int x = startX + (i % width) * 18, y = startY + MathHelper.floor(i / width) * 18;
            if (!canBeFit(x, y, listArea))
                continue;
            j++;
```
Here, the `j++` would have to be inserted before the `if (j >= currentDisplayed.size()) break;`. Or else, it will cause the `the java.lang.IndexOutOfBoundsException` and crash.