### PR TITLE
Adds a result that will return to the previous screen

### DIFF
--- a/src/main/java/me/shedaniel/rei/api/AutoTransferHandler.java
+++ b/src/main/java/me/shedaniel/rei/api/AutoTransferHandler.java
@@ -47,7 +47,11 @@ public interface AutoTransferHandler {
         static Result createSuccessful() {
             return new ResultImpl();
         }
-        
+
+        static Result createSuccessfulReturnToScreen() {
+            return new ResultImpl(true, true, true);
+        }
+
         static Result createNotApplicable() {
             return new ResultImpl(false);
         }
@@ -71,6 +75,12 @@ public interface AutoTransferHandler {
         int getColor();
         
         boolean isSuccessful();
+
+        /**
+         * Applicable if {@link #isSuccessful()} is true. Will return
+         * to the previous screen rather than staying open.
+         */
+        boolean isReturnToScreen();
         
         boolean isApplicable();
         
@@ -111,21 +121,25 @@ public interface AutoTransferHandler {
     
     @ApiStatus.Internal
     final class ResultImpl implements Result {
-        private boolean successful, applicable;
+        private boolean successful, applicable, returnToScreen;
         private String errorKey;
         private IntList integers = new IntArrayList();
         private int color;
         
         private ResultImpl() {
-            this.successful = true;
-            this.applicable = true;
+            this(true, true, false);
         }
         
         public ResultImpl(boolean applicable) {
-            this.successful = false;
-            this.applicable = applicable;
+            this(false, applicable, false);
         }
-        
+
+        public ResultImpl(boolean successful, boolean applicable, boolean returnToScreen) {
+            this.successful = successful;
+            this.applicable = applicable;
+            this.returnToScreen = returnToScreen;
+        }
+
         public ResultImpl(String errorKey, IntList integers, int color) {
             this.successful = false;
             this.applicable = true;
@@ -144,12 +158,17 @@ public interface AutoTransferHandler {
         public boolean isSuccessful() {
             return successful;
         }
-        
+
         @Override
         public boolean isApplicable() {
             return applicable;
         }
-        
+
+        @Override
+        public boolean isReturnToScreen() {
+            return returnToScreen;
+        }
+
         @Override
         public String getErrorKey() {
             return errorKey;

--- a/src/main/java/me/shedaniel/rei/impl/InternalWidgets.java
+++ b/src/main/java/me/shedaniel/rei/impl/InternalWidgets.java
@@ -65,8 +65,12 @@ public final class InternalWidgets {
                     for (AutoTransferHandler autoTransferHandler : RecipeHelper.getInstance().getSortedAutoCraftingHandler())
                         try {
                             AutoTransferHandler.Result result = autoTransferHandler.handle(context);
-                            if (result.isSuccessful())
+                            if (result.isSuccessful()) {
+                                if (result.isReturnToScreen()) {
+                                    break; // Same as failing, but doesn't ask other handlers
+                                }
                                 return;
+                            }
                         } catch (Exception e) {
                             e.printStackTrace();
                         }


### PR DESCRIPTION
I know that I could also do this by returning "failed", but that will still call other
auto transfer handlers.

The use case for this is a "pattern encoding screen" that allows transfering
REI patterns into the terminal screen, but doesn't perform any actual
crafting. So when the user clicks the button, the REI screen should close.