### PR TITLE
Add missing lang for too long nbt.

### DIFF
--- a/runtime/src/main/resources/assets/roughlyenoughitems/lang/en_us.json
+++ b/runtime/src/main/resources/assets/roughlyenoughitems/lang/en_us.json
@@ -43,6 +43,7 @@
   "text.rei.config.optifine.description": "The configuration screen is incompatible with your instance of OptiFine / OptiFabric.",
   "text.rei.cheat_items": "Gave [{item_name}§f] x{item_count} to {player_name}.",
   "text.rei.failed_cheat_items": "§cFailed to give items.",
+  "text.rei.too_long_nbt": "§cItem NBT is too long to be applied in multiplayer.",
   "ordering.rei.ascending": "Ascending",
   "ordering.rei.descending": "Descending",
   "ordering.rei.registry": "Registry",


### PR DESCRIPTION
Currently missing the "too_long_nbt" translation, which only occurs on servers.
![image](https://user-images.githubusercontent.com/10999535/125873509-d60b7267-b4e6-4c04-bdca-186a774fff1f.png)
