### PR TITLE
Make Label tooltips use Components instead of Strings

### DIFF
--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/ScreenOverlayImpl.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/ScreenOverlayImpl.java
@@ -68,6 +68,7 @@ import me.shedaniel.rei.impl.client.gui.modules.Menu;
 import me.shedaniel.rei.impl.client.gui.widget.*;
 import me.shedaniel.rei.impl.client.gui.widget.search.OverlaySearchField;
 import me.shedaniel.rei.impl.common.util.Weather;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.chat.NarratorChatListener;
 import net.minecraft.client.gui.components.events.GuiEventListener;
@@ -337,7 +338,7 @@ public class ScreenOverlayImpl extends ScreenOverlay {
                         ENTRY_LIST_WIDGET.updateEntriesPosition();
                     }, ENTRY_LIST_WIDGET.getPage(), ENTRY_LIST_WIDGET.getTotalPages());
                 }
-            }).tooltipLine(I18n.get("text.rei.go_back_first_page") + "\n \n§7" + I18n.get("text.rei.shift_click_to", I18n.get("text.rei.choose_page"))).focusable(false).onRender((matrices, label) -> {
+            }).tooltip(new TranslatableComponent("text.rei.go_back_first_page"), new TextComponent(" "), new TranslatableComponent("text.rei.shift_click_to", new TranslatableComponent("text.rei.choose_page")).withStyle(ChatFormatting.GRAY)).focusable(false).onRender((matrices, label) -> {
                 label.setClickable(ENTRY_LIST_WIDGET.getTotalPages() > 1);
                 label.setMessage(new TextComponent(String.format("%s/%s", ENTRY_LIST_WIDGET.getPage() + 1, Math.max(ENTRY_LIST_WIDGET.getTotalPages(), 1))));
             }).rainbow(new Random().nextFloat() < 1.0E-4D || ClientHelperImpl.getInstance().isAprilFools.get()));

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/screen/CompositeDisplayViewingScreen.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/screen/CompositeDisplayViewingScreen.java
@@ -54,7 +54,6 @@ import me.shedaniel.rei.impl.display.DisplaySpec;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.chat.NarratorChatListener;
 import net.minecraft.client.gui.components.events.GuiEventListener;
-import net.minecraft.client.resources.language.I18n;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
@@ -227,7 +226,7 @@ public class CompositeDisplayViewingScreen extends AbstractDisplayViewingScreen 
         
         this.widgets.add(Widgets.createClickableLabel(new Point(bounds.x + 4 + scrollListBounds.width / 2, bounds.y + 6), categories.get(selectedCategoryIndex).getTitle(), label -> {
             ViewSearchBuilder.builder().addAllCategories().open();
-        }).tooltipLine(I18n.get("text.rei.view_all_categories")).noShadow().color(0xFF404040, 0xFFBBBBBB).hoveredColor(0xFF0041FF, 0xFFFFBD4D));
+        }).tooltip(new TranslatableComponent("text.rei.view_all_categories")).noShadow().color(0xFF404040, 0xFFBBBBBB).hoveredColor(0xFF0041FF, 0xFFFFBD4D));
         
         this._children().addAll(buttonList);
         this.widgets.addAll(tabs);

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/screen/DefaultDisplayViewingScreen.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/screen/DefaultDisplayViewingScreen.java
@@ -58,12 +58,12 @@ import me.shedaniel.rei.impl.client.gui.widget.InternalWidgets;
 import me.shedaniel.rei.impl.client.gui.widget.TabWidget;
 import me.shedaniel.rei.impl.client.gui.widget.basewidgets.PanelWidget;
 import me.shedaniel.rei.impl.display.DisplaySpec;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.chat.NarratorChatListener;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.resources.language.I18n;
 import net.minecraft.client.resources.sounds.SimpleSoundInstance;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.TextComponent;
@@ -187,7 +187,7 @@ public class DefaultDisplayViewingScreen extends AbstractDisplayViewingScreen {
                 .onClick(button -> previousCategory()).tooltipLine(new TranslatableComponent("text.rei.previous_category")));
         this.widgets.add(Widgets.createClickableLabel(new Point(bounds.getCenterX(), bounds.getY() + 7), getCurrentCategory().getTitle(), clickableLabelWidget -> {
             ViewSearchBuilder.builder().addAllCategories().open();
-        }).tooltipLine(I18n.get("text.rei.view_all_categories")));
+        }).tooltip(new TranslatableComponent("text.rei.view_all_categories")));
         this.widgets.add(categoryNext = Widgets.createButton(new Rectangle(bounds.getMaxX() - 17, bounds.getY() + 5, 12, 12), new TranslatableComponent("text.rei.right_arrow"))
                 .onClick(button -> nextCategory()).tooltipLine(new TranslatableComponent("text.rei.next_category")));
         this.categoryBack.setEnabled(categories.size() > 1);
@@ -213,7 +213,7 @@ public class DefaultDisplayViewingScreen extends AbstractDisplayViewingScreen {
         }).onRender((matrices, label) -> {
             label.setMessage(new ImmutableTextComponent(String.format("%d/%d", page + 1, getCurrentTotalPages())));
             label.setClickable(getCurrentTotalPages() > 1);
-        }).tooltipSupplier(label -> label.isClickable() ? I18n.get("text.rei.go_back_first_page") + "\n \n§7" + I18n.get("text.rei.shift_click_to", I18n.get("text.rei.choose_page")) : null));
+        }).tooltipFunction(label -> label.isClickable() ? new Component[]{new TranslatableComponent("text.rei.go_back_first_page"), new TextComponent(" "), new TranslatableComponent("text.rei.shift_click_to", new TranslatableComponent("text.rei.choose_page")).withStyle(ChatFormatting.GRAY)} : null));
         this.widgets.add(recipeNext = Widgets.createButton(new Rectangle(bounds.getMaxX() - 17, bounds.getY() + 19, 12, 12), new TranslatableComponent("text.rei.right_arrow"))
                 .onClick(button -> {
                     page++;

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/basewidgets/LabelWidget.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/basewidgets/LabelWidget.java
@@ -37,6 +37,7 @@ import me.shedaniel.rei.api.client.gui.widgets.Widgets;
 import me.shedaniel.rei.impl.client.gui.text.TextTransformations;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.locale.Language;
+import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.FormattedText;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.util.FormattedCharSequence;
@@ -70,7 +71,7 @@ public final class LabelWidget extends Label {
                 return hoveredColor.value();
             }, ValueAnimator.typicalTransitionTime() / 2);
     private Point point;
-    @Nullable private Function<Label, @Nullable String> tooltip;
+    @Nullable private Function<Label, @Nullable Component[]> tooltip;
     @Nullable private Consumer<Label> onClick;
     @Nullable private BiConsumer<PoseStack, Label> onRender;
     private FormattedText text;
@@ -126,14 +127,14 @@ public final class LabelWidget extends Label {
     
     @Override
     @Nullable
-    public final String getTooltip() {
+    public final Component[] getTooltipLines() {
         if (tooltip == null)
             return null;
         return tooltip.apply(this);
     }
     
     @Override
-    public final void setTooltip(@Nullable Function<Label, @Nullable String> tooltip) {
+    public final void setTooltipFunction(@Nullable Function<Label, @Nullable Component[]> tooltip) {
         this.tooltip = tooltip;
     }
     
@@ -251,12 +252,12 @@ public final class LabelWidget extends Label {
                 break;
         }
         if (isHovered(mouseX, mouseY)) {
-            String tooltip = getTooltip();
+            Component[] tooltip = getTooltipLines();
             if (tooltip != null) {
                 if (!focused && containsMouse(mouseX, mouseY))
-                    Tooltip.create(Stream.of(tooltip.split("\n")).map(TextComponent::new).collect(Collectors.toList())).queue();
+                    Tooltip.create(tooltip).queue();
                 else if (focused)
-                    Tooltip.create(point, Stream.of(tooltip.split("\n")).map(TextComponent::new).collect(Collectors.toList())).queue();
+                    Tooltip.create(point, tooltip).queue();
             }
         }
     }


### PR DESCRIPTION
Attempted to keep all old methods for backwards compatibility reasons, but marked as Deprecated and ScheduledForRemoval... and thus had to choose a not-so-ideal method name or two for erasure conflict reasons