### PR TITLE
Implement JEICatalystLookup and JEIRecipeCategoriesLookup, fixes #927

### DIFF
--- a/api/src/main/java/me/shedaniel/rei/api/common/util/CollectionUtils.java
+++ b/api/src/main/java/me/shedaniel/rei/api/common/util/CollectionUtils.java
@@ -138,6 +138,22 @@ public class CollectionUtils {
         }
         return l;
     }
+
+    public static <T, R> Set<R> mapToSet(Collection<T> list, Function<T, R> function) {
+        Set<R> l = new HashSet<>(list.size() + 1);
+        for (T t : list) {
+            l.add(function.apply(t));
+        }
+        return l;
+    }
+
+    public static <T, R> Set<R> mapToSet(Iterable<T> list, Function<T, R> function) {
+        Set<R> l = new HashSet<>();
+        for (T t : list) {
+            l.add(function.apply(t));
+        }
+        return l;
+    }
     
     public static <T, R> List<R> mapIndexed(Iterable<T> list, IndexedFunction<T, R> function) {
         List<R> l = list instanceof Collection ? new ArrayList<>(((Collection<T>) list).size() + 1) : new ArrayList<>();

--- a/jei-compatibility-layer/src/main/java/me/shedaniel/rei/jeicompat/wrap/JEICatalystLookup.java
+++ b/jei-compatibility-layer/src/main/java/me/shedaniel/rei/jeicompat/wrap/JEICatalystLookup.java
@@ -1,0 +1,44 @@
+package me.shedaniel.rei.jeicompat.wrap;
+
+import lombok.experimental.ExtensionMethod;
+import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.jeicompat.JEIPluginDetector;
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import mezz.jei.api.recipe.IRecipeCatalystLookup;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@ExtensionMethod(JEIPluginDetector.class)
+public class JEICatalystLookup implements IRecipeCatalystLookup {
+    private final CategoryIdentifier<?> category;
+    private boolean includeHidden = false;
+
+    public JEICatalystLookup(CategoryIdentifier<?> category) {
+        this.category = category;
+    }
+
+    @Override
+    public IRecipeCatalystLookup includeHidden() {
+        this.includeHidden = true;
+        return this;
+    }
+
+    @Override
+    public Stream<ITypedIngredient<?>> get() {
+        Stream<ITypedIngredient<?>> stream = CategoryRegistry.getInstance().get(category)
+                .getWorkstations()
+                .stream()
+                .flatMap(Collection::stream)
+                .map(entry -> entry.typedJeiValue());
+        return includeHidden ? stream : stream.filter(JEIIngredientVisibility.INSTANCE::isIngredientVisible);
+    }
+
+    @Override
+    public <S> Stream<S> get(IIngredientType<S> ingredientType) {
+        return get().map(entry -> entry.getIngredient(ingredientType)).flatMap(Optional::stream);
+    }
+}

--- a/jei-compatibility-layer/src/main/java/me/shedaniel/rei/jeicompat/wrap/JEIRecipeCategoriesLookup.java
+++ b/jei-compatibility-layer/src/main/java/me/shedaniel/rei/jeicompat/wrap/JEIRecipeCategoriesLookup.java
@@ -23,32 +23,74 @@
 
 package me.shedaniel.rei.jeicompat.wrap;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import lombok.experimental.ExtensionMethod;
+import me.shedaniel.rei.api.client.registry.category.CategoryRegistry;
+import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
+import me.shedaniel.rei.api.client.view.ViewSearchBuilder;
+import me.shedaniel.rei.api.common.category.CategoryIdentifier;
+import me.shedaniel.rei.api.common.entry.EntryStack;
+import me.shedaniel.rei.api.common.util.CollectionUtils;
+import me.shedaniel.rei.jeicompat.JEIPluginDetector;
 import mezz.jei.api.recipe.IFocus;
 import mezz.jei.api.recipe.IRecipeCategoriesLookup;
+import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 
 import java.util.Collection;
+import java.util.Set;
 import java.util.stream.Stream;
 
+@ExtensionMethod(JEIPluginDetector.class)
 public class JEIRecipeCategoriesLookup implements IRecipeCategoriesLookup {
+
+    private Set<CategoryIdentifier<?>> categoryFilter = Set.of();
+    private Set<CategoryIdentifier<?>> focusFilter = Set.of();
+    private boolean includeHidden = false;
+
     @Override
     public IRecipeCategoriesLookup limitTypes(Collection<RecipeType<?>> recipeTypes) {
-        return null;
+        Preconditions.checkNotNull(recipeTypes, "recipeTypes");
+        this.categoryFilter = CollectionUtils.mapToSet(recipeTypes, type -> type.categoryId());
+        return this;
     }
-    
+
     @Override
     public IRecipeCategoriesLookup limitFocus(Collection<? extends IFocus<?>> focuses) {
-        return null;
+        Preconditions.checkNotNull(focuses, "focuses");
+        if (!focuses.isEmpty()) {
+            ViewSearchBuilder builder = ViewSearchBuilder.builder();
+            for (IFocus<?> focus : focuses) {
+                EntryStack<?> stack = focus.getTypedValue().unwrapStack();
+                if (focus.getRole() == RecipeIngredientRole.INPUT || focus.getRole() == RecipeIngredientRole.CATALYST) {
+                    builder.addUsagesFor(stack);
+                } else {
+                    builder.addRecipesFor(stack);
+                }
+            }
+            this.focusFilter = CollectionUtils.mapToSet(builder.buildMapInternal().keySet(), DisplayCategory::getCategoryIdentifier);
+        }
+        return this;
     }
-    
+
     @Override
     public IRecipeCategoriesLookup includeHidden() {
-        return null;
+        this.includeHidden = true;
+        return this;
     }
-    
+
     @Override
     public Stream<IRecipeCategory<?>> get() {
-        return null;
+        Stream<? extends IRecipeCategory<?>> stream = CollectionUtils.filterAndMap(CategoryRegistry.getInstance(), cat -> {
+            if (!includeHidden && CategoryRegistry.getInstance().isCategoryInvisible(cat.getCategory())) {
+                return false;
+            }
+
+            Set<CategoryIdentifier<?>> filter = Sets.intersection(categoryFilter, focusFilter);
+            return filter.isEmpty() || filter.contains(cat.getCategoryIdentifier());
+        }, cat -> cat.getCategory().wrapCategory()).stream();
+        return (Stream<IRecipeCategory<?>>) stream;
     }
 }

--- a/jei-compatibility-layer/src/main/java/me/shedaniel/rei/jeicompat/wrap/JEIRecipeManager.java
+++ b/jei-compatibility-layer/src/main/java/me/shedaniel/rei/jeicompat/wrap/JEIRecipeManager.java
@@ -57,12 +57,12 @@ public enum JEIRecipeManager implements IRecipeManager {
     
     @Override
     public IRecipeCategoriesLookup createRecipeCategoryLookup() {
-        return null;
+        return new JEIRecipeCategoriesLookup();
     }
     
     @Override
     public IRecipeCatalystLookup createRecipeCatalystLookup(RecipeType<?> recipeType) {
-        return null;
+        return new JEICatalystLookup(recipeType.categoryId());
     }
     
     @Override


### PR DESCRIPTION
As the title states.

Note these are pretty primitive implementations so optimisations can still be done before merging, though that said *something* implementing these interfaces should be added within the near future as all mods depending on JEI 11 will need this :P