### PR TITLE
Improvements to Composting category

### DIFF
--- a/default-plugin/src/main/java/me/shedaniel/rei/plugin/client/DefaultClientPlugin.java
+++ b/default-plugin/src/main/java/me/shedaniel/rei/plugin/client/DefaultClientPlugin.java
@@ -261,11 +261,10 @@ public class DefaultClientPlugin implements REIClientPlugin, BuiltinClientPlugin
         if (ComposterBlock.COMPOSTABLES.isEmpty()) {
             ComposterBlock.bootStrap();
         }
-        int page = 0;
-        Iterator<List<Object2FloatMap.Entry<ItemLike>>> iterator = Iterators.partition(ComposterBlock.COMPOSTABLES.object2FloatEntrySet().stream().sorted(Map.Entry.comparingByValue()).iterator(), 35);
+        Iterator<List<EntryIngredient>> iterator = Iterators.partition(ComposterBlock.COMPOSTABLES.object2FloatEntrySet().stream().sorted(Map.Entry.comparingByValue()).map(entry -> EntryIngredients.of(entry.getKey())).iterator(), 35);
         while (iterator.hasNext()) {
-            List<Object2FloatMap.Entry<ItemLike>> entries = iterator.next();
-            registry.add(DefaultCompostingDisplay.of(entries, Collections.singletonList(EntryIngredients.of(new ItemStack(Items.BONE_MEAL))), page++));
+            List<EntryIngredient> entries = iterator.next();
+            registry.add(new DefaultCompostingDisplay(entries, Collections.singletonList(EntryIngredients.of(new ItemStack(Items.BONE_MEAL)))));
         }
         DummyAxeItem.getStrippedBlocksMap().entrySet().stream().sorted(Comparator.comparing(b -> Registry.BLOCK.getKey(b.getKey()))).forEach(set -> {
             registry.add(new DefaultStrippingDisplay(EntryStacks.of(set.getKey()), EntryStacks.of(set.getValue())));

--- a/default-plugin/src/main/java/me/shedaniel/rei/plugin/client/categories/DefaultCompostingCategory.java
+++ b/default-plugin/src/main/java/me/shedaniel/rei/plugin/client/categories/DefaultCompostingCategory.java
@@ -97,7 +97,7 @@ public class DefaultCompostingCategory implements DisplayCategory<DefaultCompost
                 EntryIngredient entryIngredient = stacks.size() > i ? stacks.get(i) : EntryIngredient.empty();
                 if (!entryIngredient.isEmpty()) {
                     ItemStack firstStack = (ItemStack) entryIngredient.get(0).getValue();
-                    float chance = ComposterBlock.COMPOSTABLES.object2FloatEntrySet().stream().filter(entry -> entry.getKey() != null && firstStack.is(entry.getKey().asItem())).findAny().map(Map.Entry::getValue).orElse(0f);
+                    float chance = ComposterBlock.COMPOSTABLES.getFloat(firstStack.getItem());
                     if (chance > 0.0f) {
                         entryIngredient = entryIngredient.map(stack -> stack.copy().tooltip(Component.translatable("text.rei.composting.chance", Mth.clamp(Mth.fastFloor(chance * 100), 0, 100)).withStyle(ChatFormatting.YELLOW)));
                     }

--- a/default-plugin/src/main/java/me/shedaniel/rei/plugin/common/displays/DefaultCompostingDisplay.java
+++ b/default-plugin/src/main/java/me/shedaniel/rei/plugin/common/displays/DefaultCompostingDisplay.java
@@ -42,7 +42,7 @@ public class DefaultCompostingDisplay extends BasicDisplay {
 
     private final int page;
 
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public static DefaultCompostingDisplay of(List<Object2FloatMap.Entry<ItemLike>> inputs, List<EntryIngredient> output, int page) {
         EntryIngredient[] inputIngredients = new EntryIngredient[inputs.size()];
         int i = 0;

--- a/default-plugin/src/main/java/me/shedaniel/rei/plugin/common/displays/DefaultCompostingDisplay.java
+++ b/default-plugin/src/main/java/me/shedaniel/rei/plugin/common/displays/DefaultCompostingDisplay.java
@@ -24,6 +24,8 @@
 package me.shedaniel.rei.plugin.common.displays;
 
 import it.unimi.dsi.fastutil.objects.Object2FloatMap;
+import org.jetbrains.annotations.ApiStatus;
+
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.basic.BasicDisplay;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
@@ -36,8 +38,11 @@ import java.util.Arrays;
 import java.util.List;
 
 public class DefaultCompostingDisplay extends BasicDisplay {
-    private int page;
-    
+    private static int pages;
+
+    private final int page;
+
+    @Deprecated
     public static DefaultCompostingDisplay of(List<Object2FloatMap.Entry<ItemLike>> inputs, List<EntryIngredient> output, int page) {
         EntryIngredient[] inputIngredients = new EntryIngredient[inputs.size()];
         int i = 0;
@@ -47,18 +52,30 @@ public class DefaultCompostingDisplay extends BasicDisplay {
         }
         return new DefaultCompostingDisplay(Arrays.asList(inputIngredients), output, page);
     }
-    
+
+    @ApiStatus.Internal
     public DefaultCompostingDisplay(List<EntryIngredient> inputs, List<EntryIngredient> outputs, CompoundTag tag) {
         this(inputs, outputs, tag.getInt("page"));
     }
-    
+
+    public DefaultCompostingDisplay(List<EntryIngredient> inputs, List<EntryIngredient> outputs) {
+        super(inputs, outputs);
+        this.page = pages++;
+    }
+
+    @ApiStatus.Internal
     public DefaultCompostingDisplay(List<EntryIngredient> inputs, List<EntryIngredient> outputs, int page) {
         super(inputs, outputs);
         this.page = page;
+        if (pages <= page) pages = page + 1;
     }
     
     public int getPage() {
         return page;
+    }
+
+    public static int getPages() {
+        return pages;
     }
     
     @Override


### PR DESCRIPTION
A few (mostly backend) improvements to the Composting category, including a bug fix

1. Fixed the composting chance tooltip not showing up
2. `DefaultCompostingDisplay.of` is no longer used and has been deprecated in favor of simply mapping the stream to entry ingredients before using the constructor
3. Page count is kept track of internally and used to avoid having to specify the page number manually in a constructor, as a result the constructors that do specify it have been marked as internal as they should only be used by the serializer, but remain public for backwards compatibility with any mods that may use them for some reason