### PR TITLE
[1.19] Only start draggin with left mouse button, not other mouse buttons

### DIFF
--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/dragging/CurrentDraggingStack.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/dragging/CurrentDraggingStack.java
@@ -172,7 +172,7 @@ public class CurrentDraggingStack extends Widget implements LateRenderable, Drag
     
     @Override
     public boolean mouseDragged(double mouseX1, double mouseY1, int button, double mouseX2, double mouseY2) {
-        return entry != null && entry.dragging;
+        return button == 0 && entry != null && entry.dragging;
     }
     
     private boolean drop() {

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/dragging/CurrentDraggingStack.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/dragging/CurrentDraggingStack.java
@@ -154,6 +154,9 @@ public class CurrentDraggingStack extends Widget implements LateRenderable, Drag
     
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (button != 0) {
+            return false;
+        }
         drop();
         DraggableComponent<?> hoveredStack = provider.getHovered(this, mouseX, mouseY);
         if (hoveredStack != null) {


### PR DESCRIPTION
Every mouse button being able to drag items can be annoying if those mouse buttons are used for something else. (For example, push-to-talk in Discord)
It is reasonable to assume that the vast majority of users only ever use the left mouse button to drag, so limiting the dragging ability to the left mouse button should create the best experience for almost all users.