### PR TITLE
Fix Render Misbehaves Under Certain Conditions [1.19]

### DIFF
--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/screen/CompositeDisplayViewingScreen.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/screen/CompositeDisplayViewingScreen.java
@@ -110,9 +110,6 @@ public class CompositeDisplayViewingScreen extends AbstractDisplayViewingScreen 
         int guiHeight = Mth.clamp(category.getDisplayHeight() + 40, 166, largestHeight);
         this.bounds = new Rectangle(width / 2 - guiWidth / 2, height / 2 - guiHeight / 2, guiWidth, guiHeight);
         
-        this.initTabs(this.bounds.width);
-        this.widgets.addAll(this.tabs.widgets());
-        
         List<EntryIngredient> workstations = CategoryRegistry.getInstance().get(category.getCategoryIdentifier()).getWorkstations();
         if (!workstations.isEmpty()) {
             int ww = Mth.floor((bounds.width - 16) / 18f);
@@ -161,6 +158,9 @@ public class CompositeDisplayViewingScreen extends AbstractDisplayViewingScreen 
         Optional<ButtonArea> supplier = CategoryRegistry.getInstance().get(category.getCategoryIdentifier()).getPlusButtonArea();
         if (supplier.isPresent() && supplier.get().get(recipeBounds) != null)
             this.widgets.add(Widgets.withTranslate(InternalWidgets.createAutoCraftingButtonWidget(recipeBounds, supplier.get().get(recipeBounds), Component.literal(supplier.get().getButtonText()), display::provideInternalDisplay, display::provideInternalDisplayIds, setupDisplay, category), 0, 0, 100));
+
+        this.initTabs(this.bounds.width);
+        this.widgets.addAll(this.tabs.widgets());
         
         int index = 0;
         for (DisplaySpec recipeDisplay : categoryMap.get(category)) {

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/BatchedEntryRendererManager.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/BatchedEntryRendererManager.java
@@ -186,7 +186,7 @@ public class BatchedEntryRendererManager {
             try {
                 @SuppressWarnings("rawtypes")
                 EntryStack currentEntry = entry.getCurrentEntry();
-                currentEntry.setZ(100);
+                currentEntry.setZ(entry.getBounds().contains(mouseX, mouseY) ? 150 : 100);
                 firstRenderer.renderBase(currentEntry, extraData[i++], matrices, immediate, entry.getInnerBounds(), mouseX, mouseY, delta);
                 if (debugTime && !currentEntry.isEmpty()) size.increment();
             } catch (Throwable throwable) {

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/entrylist/EntryListStackEntry.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/entrylist/EntryListStackEntry.java
@@ -109,7 +109,8 @@ public class EntryListStackEntry extends DisplayedEntryWidget {
         Rectangle bounds = getBounds();
         
         if (collapsedStack != null) {
-            fillGradient(matrices, bounds.x, bounds.y, bounds.getMaxX(), bounds.getMaxY(), 0x34FFFFFF, 0x34FFFFFF);
+            fillGradient(matrices, bounds.getCenterX() - entrySize() / 2, bounds.getCenterY() - entrySize() / 2,
+                    bounds.getCenterX() + entrySize() / 2 + 1, bounds.getCenterY() + entrySize() / 2 + 1, 0x34FFFFFF, 0x34FFFFFF);
         }
         
         super.drawBackground(matrices, mouseX, mouseY, delta);

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/entrylist/EntryListStackEntry.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/entrylist/EntryListStackEntry.java
@@ -109,8 +109,9 @@ public class EntryListStackEntry extends DisplayedEntryWidget {
         Rectangle bounds = getBounds();
         
         if (collapsedStack != null) {
-            fillGradient(matrices, bounds.getCenterX() - entrySize() / 2, bounds.getCenterY() - entrySize() / 2,
-                    bounds.getCenterX() + entrySize() / 2 + 1, bounds.getCenterY() + entrySize() / 2 + 1, 0x34FFFFFF, 0x34FFFFFF);
+            int entrySize = entrySize();
+            fillGradient(matrices, bounds.getCenterX() - entrySize / 2, bounds.getCenterY() - entrySize / 2,
+                    bounds.getCenterX() + entrySize / 2 + 1, bounds.getCenterY() + entrySize / 2 + 1, 0x34FFFFFF, 0x34FFFFFF);
         }
         
         super.drawBackground(matrices, mouseX, mouseY, delta);

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/entrylist/ScrolledEntryListWidget.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/entrylist/ScrolledEntryListWidget.java
@@ -75,7 +75,7 @@ public class ScrolledEntryListWidget extends CollapsingEntryListWidget {
             EntryListStackEntry entry = entries.get(cont);
             Rectangle entryBounds = entry.getBounds();
             
-            entryBounds.y = entry.backupY - scrolling.scrollAmountInt();
+            entryBounds.y = entry.backupY - scrolling.scrollAmountInt() - entryBounds.height / 2 + entrySize() / 2;
             if (entryBounds.y > this.bounds.getMaxY()) break;
             if (stacks.size() <= i) break;
             if (notSteppingOnExclusionZones(entryBounds.x, entryBounds.y, entryBounds.width, entryBounds.height)) {

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/entrylist/ScrolledEntryListWidget.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/entrylist/ScrolledEntryListWidget.java
@@ -64,8 +64,9 @@ public class ScrolledEntryListWidget extends CollapsingEntryListWidget {
     protected void renderEntries(boolean fastEntryRendering, PoseStack matrices, int mouseX, int mouseY, float delta) {
         ScissorsHandler.INSTANCE.scissor(bounds);
         
-        int skip = Math.max(0, Mth.floor(scrolling.scrollAmount() / (float) entrySize()));
-        int nextIndex = skip * innerBounds.width / entrySize();
+        int entrySize = entrySize();
+        int skip = Math.max(0, Mth.floor(scrolling.scrollAmount() / (float) entrySize));
+        int nextIndex = skip * innerBounds.width / entrySize;
         this.blockedCount = 0;
         BatchedEntryRendererManager helper = new BatchedEntryRendererManager();
         Int2ObjectMap<CollapsedStack> indexedCollapsedStack = getCollapsedStackIndexed();
@@ -75,7 +76,7 @@ public class ScrolledEntryListWidget extends CollapsingEntryListWidget {
             EntryListStackEntry entry = entries.get(cont);
             Rectangle entryBounds = entry.getBounds();
             
-            entryBounds.y = entry.backupY - scrolling.scrollAmountInt() - entryBounds.height / 2 + entrySize() / 2;
+            entryBounds.y = entry.backupY - scrolling.scrollAmountInt() - entryBounds.height / 2 + entrySize / 2;
             if (entryBounds.y > this.bounds.getMaxY()) break;
             if (stacks.size() <= i) break;
             if (notSteppingOnExclusionZones(entryBounds.x, entryBounds.y, entryBounds.width, entryBounds.height)) {


### PR DESCRIPTION
# This Pull Request Fixes 2 Misbehaves:

## 1. Unexpected Chattering and Bad Zooming

First, **set the REI config to:**

`isFocusModeZoomed: true` & `scrollingEntryListWidget: true`

Then, hover your mouse on the side bar, the icons are **abnormally zoomed from top instead of center** and **sometimes scattering.**

**Check this short video for further information:**

https://user-images.githubusercontent.com/68179735/215263529-c4c00d35-c560-43a2-8266-eb0076d57673.mov

## 2. Tabs Under Panel

First, **set the REI config to:**

`recipeScreenType: COMPOSITE`

Then, check a recipe and you will find **top tabs under main panel,** instead of **above main panel** like the `DEFAULT` mode, or the preview image of `COMPOSITE` mode shows.

**Check this image for further information:**

<img width="1620" alt="TABS-Commented" src="https://user-images.githubusercontent.com/68179735/215263676-82e228b9-bbcf-42c9-9168-fe89842bbd62.png">

These fixes are simple but useful, and I think they could **obviously improve user experience.** I will be very appreciate if my fixes can actually be merged, and I'm always happy to explain the codes I added if needed. The fixes are tested, and they works pretty well!