### PR TITLE
Add min version  to rei.mixins.json to fix warning in load and update compat level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Roughly Enough Items
 https://minecraft.curseforge.com/projects/roughly-enough-items <br>
-Roughly Enough Items is a mod to view Items and Recipes for Minecraft 1.13 - 1.18, supporting mod loaders from Forge, Rift to Fabric.
+Roughly Enough Items is a mod to view Items and Recipes for Minecraft 1.13 - 1.19, supporting mod loaders from Forge, Rift to Fabric.
 -----
 
 [Help translate REI on Crowdin!](https://crowdin.com/project/roughly-enough-items)

--- a/fabric/src/main/resources/rei.mixins.json
+++ b/fabric/src/main/resources/rei.mixins.json
@@ -1,8 +1,9 @@
 {
   "required": true,
+  "minVersion": "0.8",
   "package": "me.shedaniel.rei.mixin.fabric",
   "plugin": "me.shedaniel.rei.mixin.fabric.REIMixinPlugin",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "MixinClientPacketListener",
     "MixinEffectRenderingInventoryScreen",

--- a/forge/src/main/resources/pack.mcmeta
+++ b/forge/src/main/resources/pack.mcmeta
@@ -1,6 +1,6 @@
 {
   "pack": {
     "description": "Roughly Enough Items",
-    "pack_format": 6
+    "pack_format": 10
   }
 }

--- a/forge/src/main/resources/rei.mixins.json
+++ b/forge/src/main/resources/rei.mixins.json
@@ -1,7 +1,8 @@
 {
   "required": true,
+  "minVersion": "0.8",
   "package": "me.shedaniel.rei.mixin.forge",
-  "compatibilityLevel": "JAVA_8",
+  "compatibilityLevel": "JAVA_17",
   "client": [
     "MixinClientPacketListener",
     "MixinEffectRenderingInventoryScreen",


### PR DESCRIPTION
also bumps pack version to 1.19.X version 