### PR TITLE
TextFieldWidget: clamp `firstCharacterIndex` when text is changed

### DIFF
--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/basewidgets/TextFieldWidget.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/basewidgets/TextFieldWidget.java
@@ -160,6 +160,10 @@ public class TextFieldWidget extends WidgetWithBounds implements TickableWidget,
     }
     
     public void onChanged(String newText) {
+        int length = newText.length();
+        if (this.firstCharacterIndex > length) {
+            this.firstCharacterIndex = length;
+        }
         if (this.responder != null) {
             this.responder.accept(newText);
         }
@@ -409,7 +413,7 @@ public class TextFieldWidget extends WidgetWithBounds implements TickableWidget,
     public void render(PoseStack matrices, int mouseX, int mouseY, float delta) {
         if (this.isVisible()) {
             this.renderBorder(matrices);
-            
+
             int color = this.editable ? this.editableColor : this.notEditableColor;
             int int_4 = this.cursorPos - this.firstCharacterIndex;
             int int_5 = this.highlightPos - this.firstCharacterIndex;
@@ -582,7 +586,7 @@ public class TextFieldWidget extends WidgetWithBounds implements TickableWidget,
             if (this.firstCharacterIndex > j) {
                 this.firstCharacterIndex = j;
             }
-            
+
             int width = this.getWidth();
             String clippedText = this.font.plainSubstrByWidth(this.text.substring(this.firstCharacterIndex), width);
             int int_4 = clippedText.length() + this.firstCharacterIndex;


### PR DESCRIPTION
Fixes a spurious crash in `render(..)` when it may have been out of bounds before.

I had this crash happen twice on 1.18.2 in Stoneblock 3 ([crash log](https://pastebin.com/ZgLGie3k)). I don't have steps to reproduce, but I haven't had the issue since applying the fix (since, logically, the value can no longer be out of bounds). This may be a band-aid fix for a subtler bug, but at least it stops things from blowing up.