### PR TITLE
Use correct buffer source for rendering

### DIFF
--- a/api/src/main/java/me/shedaniel/rei/api/client/entry/renderer/BatchedEntryRenderer.java
+++ b/api/src/main/java/me/shedaniel/rei/api/client/entry/renderer/BatchedEntryRenderer.java
@@ -28,7 +28,6 @@ import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.api.common.entry.EntryStack;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.MultiBufferSource;
 
@@ -107,7 +106,7 @@ public interface BatchedEntryRenderer<T, E> extends EntryRenderer<T> {
         graphics.pose().last().normal().set(newStack.last().normal());
         E data = getExtraData(entry);
         startBatch(entry, data, graphics, delta);
-        MultiBufferSource.BufferSource immediate = Minecraft.getInstance().renderBuffers().bufferSource();
+        MultiBufferSource.BufferSource immediate = graphics.bufferSource;
         renderBase(entry, data, graphics, immediate, bounds, mouseX, mouseY, delta);
         immediate.endBatch();
         renderOverlay(entry, data, graphics, immediate, bounds, mouseX, mouseY, delta);

--- a/fabric/src/main/resources/roughlyenoughitems.accessWidener
+++ b/fabric/src/main/resources/roughlyenoughitems.accessWidener
@@ -42,3 +42,4 @@ accessible field net/minecraft/world/item/crafting/ShapedRecipe result Lnet/mine
 accessible field net/minecraft/world/item/crafting/ShapelessRecipe result Lnet/minecraft/world/item/ItemStack;
 accessible field net/minecraft/client/gui/screens/inventory/AbstractRecipeBookScreen recipeBookComponent Lnet/minecraft/client/gui/screens/recipebook/RecipeBookComponent;
 accessible method net/minecraft/client/gui/GuiGraphics innerBlit (Ljava/util/function/Function;Lnet/minecraft/resources/ResourceLocation;IIIIFFFFI)V
+accessible field net/minecraft/client/gui/GuiGraphics bufferSource Lnet/minecraft/client/renderer/MultiBufferSource$BufferSource;

--- a/forge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/forge/src/main/resources/META-INF/accesstransformer.cfg
@@ -50,3 +50,4 @@ public net.minecraft.world.item.CreativeModeTab f_256824_ # displayItemsGenerato
 public net.minecraft.world.item.CreativeModeTab$ItemDisplayBuilder
 public net.minecraft.client.multiplayer.ClientLevel f_104561_ # connection
 public net.minecraft.client.multiplayer.MultiPlayerGameMode f_105190_ # connection
+public net.minecraft.client.gui.GuiGraphics f_279627_ # bufferSource

--- a/neoforge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/neoforge/src/main/resources/META-INF/accesstransformer.cfg
@@ -52,5 +52,4 @@ public net.minecraft.world.item.crafting.ShapedRecipe result
 public net.minecraft.world.item.crafting.ShapelessRecipe result
 public net.minecraft.client.gui.screens.inventory.AbstractRecipeBookScreen recipeBookComponent
 public net.minecraft.client.gui.GuiGraphics innerBlit(Ljava/util/function/Function;Lnet/minecraft/resources/ResourceLocation;IIIIFFFFI)V
-
-
+public net.minecraft.client.gui.GuiGraphics bufferSource

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/BatchedEntryRendererManager.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/BatchedEntryRendererManager.java
@@ -26,7 +26,6 @@ package me.shedaniel.rei.impl.client.gui.widget;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -37,7 +36,6 @@ import me.shedaniel.rei.api.common.entry.EntryStack;
 import me.shedaniel.rei.api.common.util.CollectionUtils;
 import me.shedaniel.rei.impl.client.util.CrashReportUtils;
 import net.minecraft.CrashReport;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.MultiBufferSource;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -178,7 +176,7 @@ public class BatchedEntryRendererManager<T extends EntryWidget> implements Itera
         graphics.pose().last().pose().set(newStack.last().pose());
         graphics.pose().last().normal().set(newStack.last().normal());
         long l = debugTime ? System.nanoTime() : 0;
-        MultiBufferSource.BufferSource immediate = Minecraft.getInstance().renderBuffers().bufferSource();
+        MultiBufferSource.BufferSource immediate = graphics.bufferSource;
         int i = 0;
         for (T entry : entries) {
             try {

--- a/runtime/src/main/java/me/shedaniel/rei/plugin/client/entry/FluidEntryDefinition.java
+++ b/runtime/src/main/java/me/shedaniel/rei/plugin/client/entry/FluidEntryDefinition.java
@@ -271,7 +271,7 @@ public class FluidEntryDefinition implements EntryDefinition<FluidStack>, EntryS
             if (sprite == null) return;
             int color = FluidStackHooks.getColor(stack);
             
-            MultiBufferSource.BufferSource immediate = Minecraft.getInstance().renderBuffers().bufferSource();
+            MultiBufferSource.BufferSource immediate = graphics.bufferSource;
             
             SpriteRenderer.beginPass()
                     .setup(immediate, RenderType.solid())

--- a/runtime/src/main/java/me/shedaniel/rei/plugin/client/entry/ItemEntryDefinition.java
+++ b/runtime/src/main/java/me/shedaniel/rei/plugin/client/entry/ItemEntryDefinition.java
@@ -265,7 +265,7 @@ public class ItemEntryDefinition implements EntryDefinition<ItemStack>, EntrySer
                 graphics.pose().translate(bounds.getCenterX(), bounds.getCenterY(), 0);
                 graphics.pose().mulPose(new Matrix4f().scaling(1.0F, -1.0F, 1.0F));
                 graphics.pose().scale(bounds.getWidth(), bounds.getHeight(), (bounds.getWidth() + bounds.getHeight()) / 2.0F);
-                MultiBufferSource.BufferSource immediate = Minecraft.getInstance().renderBuffers().bufferSource();
+                MultiBufferSource.BufferSource immediate = graphics.bufferSource;
                 Minecraft.getInstance().getItemRenderer().render(value, ItemDisplayContext.GUI, false, graphics.pose(), immediate,
                         ITEM_LIGHT, OverlayTexture.NO_OVERLAY, model);
                 immediate.endBatch();


### PR DESCRIPTION
Uses the buffer source of the GuiGraphics instead of getting it from Minecraft. This fixes the issue with ImmediatelyFast because ImmediatelyFast changes the internal buffer source.

Fixes https://github.com/shedaniel/RoughlyEnoughItems/issues/1753