### PR TITLE
Fix shift-click issue when crafting recipes

### DIFF
--- a/runtime/src/main/java/me/shedaniel/rei/impl/common/transfer/InputSlotCrafter.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/common/transfer/InputSlotCrafter.java
@@ -139,6 +139,10 @@ public abstract class InputSlotCrafter<T extends AbstractContainerMenu, C extend
             int finalCraftsAmount = amountToFill;
             
             for (int itemId : recipeItemIds) {
+                // Fix issue with empty item id (grid slot) [shift-click issue]
+                if (itemId == 0) {
+                    continue;
+                }
                 finalCraftsAmount = Math.min(finalCraftsAmount, RecipeFinder.getStackFromId(itemId).getMaxStackSize());
             }
             


### PR DESCRIPTION
The issue was identified due to the grid's empty slots being incorrectly treated as having an itemId of 0. This fix ignores itemIds with a value of 0 when calculating the number of items to be crafted, which previously caused the resulting number of crafted items to be incorrectly set to "1".

Linked to Issue #1732