### PR TITLE
Fix Shift-click recipes on 1.21.4

### DIFF
--- a/runtime/src/main/java/me/shedaniel/rei/impl/common/transfer/InputSlotCrafter.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/common/transfer/InputSlotCrafter.java
@@ -59,6 +59,9 @@ public abstract class InputSlotCrafter<T extends AbstractContainerMenu, C extend
         this.populateRecipeFinder(recipeFinder);
         List<List<ItemStack>> ingredients = new ArrayList<>();
         for (InputIngredient<ItemStack> itemStacks : this.getInputs()) {
+            if (itemStacks.get().isEmpty()) {
+                continue;
+            }
             ingredients.add(itemStacks.get());
         }
         


### PR DESCRIPTION
Continuation of #1821, and related to #1732.

Fixes Clicking/Shift-clicking recipes to add them to a crafting grid when the crafting recipe doesn't use all 9 slots.