### PR TITLE
Fix slot interactivity issue

### DIFF
--- a/api/src/main/java/me/shedaniel/rei/api/common/transfer/info/stack/VanillaSlotAccessor.java
+++ b/api/src/main/java/me/shedaniel/rei/api/common/transfer/info/stack/VanillaSlotAccessor.java
@@ -55,12 +55,19 @@ public class VanillaSlotAccessor implements SlotAccessor {
     public Slot getSlot() {
         return slot;
     }
-    
+
+    /**
+     * Since NeoForge implemented slots may not pick up & take when it's empty, although the slot is still modifiable.
+     * A {@link VanillaSlotAccessor#canPlace(ItemStack)} check is performed later on, so this should not cause illegal modification theoretically.
+     *
+     * @see <a href="https://github.com/neoforged/NeoForge/blob/413dad9137f0e3fef53ce7dcf46f361ea5032d1a/src/main/java/net/neoforged/neoforge/items/SlotItemHandler.java#L26">SlotItemHandler::mayPlace</a>,
+     * <a href="https://github.com/neoforged/NeoForge/blob/413dad9137f0e3fef53ce7dcf46f361ea5032d1a/src/main/java/net/neoforged/neoforge/items/SlotItemHandler.java#L65">SlotItemHandler::mayPickup</a>
+     */
     @Override
     public boolean allowModification(Player player) {
-        return slot.allowModification(player);
+        return !slot.hasItem() || slot.allowModification(player);
     }
-    
+
     @Override
     public boolean canPlace(ItemStack stack) {
         return slot.mayPlace(stack);


### PR DESCRIPTION
See #1889 entry 3.
Basically, Neoforge implemented Slots ([SlotItemHandler](https://github.com/neoforged/NeoForge/blob/413dad9137f0e3fef53ce7dcf46f361ea5032d1a/src/main/java/net/neoforged/neoforge/items/SlotItemHandler.java)) have a more strict _mayPickup_ & _mayPlace_ judgement.
When judging _mayPickup_, the slot would trigger a virtual _takeItem_ operation, and rely on whether the return value (ideally the ItemStack to take) is an empty stack to judge. Hence when the slot is empty initially, it would be marked as not able to be picked up.
Similar issue occurred in _mayPlace_. When checking modifiability, the slot would try judging whether it's able to place the same item in the slot into it. But for an empty slot, the input ItemStack would be EMPTY, which is also blocked by Neoforge's judgement.
As a result, both ways will get wrong interactivity for an empty slot of **SlotItemHandler**. So we can do an extra judgement to see whether the slot is empty. Additionally, before actually placing items, a _canPlace_ check is applyed, so we don't need to worry a wrong item transfer.