### PR TITLE
Add button to suppress partial recipes data warning

### DIFF
--- a/api/src/main/java/me/shedaniel/rei/api/client/config/ConfigObject.java
+++ b/api/src/main/java/me/shedaniel/rei/api/client/config/ConfigObject.java
@@ -283,6 +283,8 @@ public interface ConfigObject {
 
     boolean doesPartialRecipesWarning();
 
+    void setDoesPartialRecipesWarning(boolean showWarning);
+
     boolean doesFastEntryRendering();
     
     boolean doesCacheEntryRendering();

--- a/api/src/main/java/me/shedaniel/rei/api/client/config/ConfigObject.java
+++ b/api/src/main/java/me/shedaniel/rei/api/client/config/ConfigObject.java
@@ -280,7 +280,9 @@ public interface ConfigObject {
     
     @ApiStatus.Experimental
     boolean doDisplayIMEHints();
-    
+
+    boolean doesPartialRecipesWarning();
+
     boolean doesFastEntryRendering();
     
     boolean doesCacheEntryRendering();

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/config/ConfigObjectImpl.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/config/ConfigObjectImpl.java
@@ -299,6 +299,10 @@ public class ConfigObjectImpl implements ConfigObject, ConfigData {
         return advanced.tooltips.doesPartialRecipesWarning;
     }
 
+    public void setDoesPartialRecipesWarning(boolean showWarning) {
+        advanced.tooltips.doesPartialRecipesWarning = showWarning;
+    }
+
     @Override
     public boolean doesFastEntryRendering() {
         return advanced.miscellaneous.newFastEntryRendering;

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/config/ConfigObjectImpl.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/config/ConfigObjectImpl.java
@@ -293,7 +293,12 @@ public class ConfigObjectImpl implements ConfigObject, ConfigData {
     public void setDoDisplayIMEHints(boolean displayIMEHints) {
         advanced.tooltips.displayIMEHints = displayIMEHints;
     }
-    
+
+    @Override
+    public boolean doesPartialRecipesWarning() {
+        return advanced.tooltips.doesPartialRecipesWarning;
+    }
+
     @Override
     public boolean doesFastEntryRendering() {
         return advanced.miscellaneous.newFastEntryRendering;
@@ -679,6 +684,7 @@ public class ConfigObjectImpl implements ConfigObject, ConfigData {
             @Comment("Declares whether favorites tooltip should be displayed.")
             public boolean displayFavoritesTooltip = false;
             public boolean displayIMEHints = true;
+            public boolean doesPartialRecipesWarning = true;
         }
         
         public static class Layout {

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/config/options/AllREIConfigGroups.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/config/options/AllREIConfigGroups.java
@@ -40,6 +40,7 @@ public interface AllREIConfigGroups {
             .add(APPEND_MOD_NAMES)
             .add(APPEND_FAVORITES_HINT);
     OptionGroup APPEARANCE_ADVANCED = make("appearance.advanced")
+            .add(PARTIAL_RECIPES_WARNING)
             .add(RAINBOW);
     OptionGroup INPUT_KEYBINDS = make("input.keybinds")
             .add(RECIPE_KEYBIND)

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/config/options/AllREIConfigOptions.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/config/options/AllREIConfigOptions.java
@@ -84,6 +84,8 @@ public interface AllREIConfigOptions {
             .enabledDisabled();
     CompositeOption<Boolean> APPEND_FAVORITES_HINT = make("appearance.append_favorites_hint", i -> i.advanced.tooltips.displayFavoritesTooltip, (i, v) -> i.advanced.tooltips.displayFavoritesTooltip = v)
             .enabledDisabled();
+    CompositeOption<Boolean> PARTIAL_RECIPES_WARNING = make("appearance.partial_recipes_warning", i -> i.advanced.tooltips.doesPartialRecipesWarning, (i, v) -> i.advanced.tooltips.doesPartialRecipesWarning = v)
+            .enabledDisabled();
     CompositeOption<ModifierKeyCode> RECIPE_KEYBIND = make("input.recipe", i -> i.basics.keyBindings.recipeKeybind.copy(), (i, v) -> i.basics.keyBindings.recipeKeybind = v)
             .keybind();
     CompositeOption<ModifierKeyCode> USAGE_KEYBIND = make("input.usage", i -> i.basics.keyBindings.usageKeybind.copy(), (i, v) -> i.basics.keyBindings.usageKeybind = v)

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/hints/ImportantWarningsWidget.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/hints/ImportantWarningsWidget.java
@@ -26,6 +26,7 @@ package me.shedaniel.rei.impl.client.gui.hints;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.RoughlyEnoughItemsCoreClient;
 import me.shedaniel.rei.api.client.ClientHelper;
+import me.shedaniel.rei.api.client.config.ConfigObject;
 import me.shedaniel.rei.api.client.gui.config.DisplayPanelLocation;
 import me.shedaniel.rei.api.client.gui.widgets.WidgetWithBounds;
 import me.shedaniel.rei.api.client.gui.widgets.Widgets;
@@ -66,7 +67,7 @@ public class ImportantWarningsWidget extends WidgetWithBounds {
             dirty = dirty && !ClientHelper.getInstance().canUseMovePackets();
         }
         
-        this.visible = dirty;
+        this.visible = dirty && ConfigObject.getInstance().doesPartialRecipesWarning();
         this.texts = List.of(
                 Component.translatable("text.rei.recipes.not.full.title").withStyle(ChatFormatting.RED),
                 Component.translatable("text.rei.recipes.not.full.desc", Component.translatable("text.rei.recipes.not.full.desc.command").withStyle(ChatFormatting.AQUA, ChatFormatting.UNDERLINE)).withStyle(ChatFormatting.GRAY)

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/hints/ImportantWarningsWidget.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/hints/ImportantWarningsWidget.java
@@ -26,6 +26,7 @@ package me.shedaniel.rei.impl.client.gui.hints;
 import me.shedaniel.math.Rectangle;
 import me.shedaniel.rei.RoughlyEnoughItemsCoreClient;
 import me.shedaniel.rei.api.client.ClientHelper;
+import me.shedaniel.rei.api.client.config.ConfigManager;
 import me.shedaniel.rei.api.client.config.ConfigObject;
 import me.shedaniel.rei.api.client.gui.config.DisplayPanelLocation;
 import me.shedaniel.rei.api.client.gui.widgets.WidgetWithBounds;
@@ -51,7 +52,8 @@ public class ImportantWarningsWidget extends WidgetWithBounds {
     private static boolean dirty = false;
     private boolean visible;
     private final Rectangle bounds;
-    private final Rectangle buttonBounds = new Rectangle();
+    private final Rectangle okayButtonBounds = new Rectangle();
+    private final Rectangle doNotShowButtonBounds = new Rectangle();
     private List<Component> texts;
     
     public ImportantWarningsWidget() {
@@ -103,23 +105,46 @@ public class ImportantWarningsWidget extends WidgetWithBounds {
             y += Minecraft.getInstance().font.wordWrapHeight(text, bounds.width * 2) / 2 + 5;
             graphics.pose().popPose();
         }
-        
+
+        MutableComponent doNotShowText = Component.translatable("text.rei.recipes.not.full.button.do_not_show_again").
+                withStyle(ChatFormatting.RED);
         MutableComponent okayText = Component.translatable("text.rei.recipes.not.full.button.okay");
+        int doNotShowTextWidth = Minecraft.getInstance().font.width(doNotShowText);
+        int okayTextWidth = Minecraft.getInstance().font.width(okayText);
+        int boundsMaxY = bounds.getMaxY();
+
         graphics.pose().pushPose();
-        graphics.pose().translate(bounds.x + bounds.width / 2 - Minecraft.getInstance().font.width(okayText) * 0.75 / 2, bounds.getMaxY() - 9, 0);
+        graphics.pose().translate(bounds.x, boundsMaxY - 9, 0);
         graphics.pose().scale(0.75f, 0.75f, 1);
-        this.buttonBounds.setBounds(bounds.x, bounds.getMaxY() - 20, bounds.width, 20);
-        graphics.drawString(Minecraft.getInstance().font, okayText, 0, 0,
-                buttonBounds.contains(mouseX, mouseY) ? 0xfffff8de : 0xAAFFFFFF);
+
+        int textHeight = 10;
+        int buttonSpacingGap = 6;
+        int doNotShowButtonAlignCenter = (int) (bounds.x + bounds.width / 2.0 - Minecraft.getInstance().font.width(doNotShowText) * 0.75 / 2);
+        int okayButtonAlignCenter = (int) (bounds.x + bounds.width / 2.0 - Minecraft.getInstance().font.width(okayText) * 0.75 / 2);
+
+        this.doNotShowButtonBounds.setBounds(bounds.x, boundsMaxY - (textHeight * 2),
+                bounds.getMaxX(), textHeight);
+        this.okayButtonBounds.setBounds(bounds.x, boundsMaxY - textHeight + buttonSpacingGap,
+                bounds.getMaxX(), textHeight - buttonSpacingGap);
+
+        graphics.drawString(Minecraft.getInstance().font, doNotShowText,
+                doNotShowButtonAlignCenter, -textHeight,
+                doNotShowButtonBounds.contains(mouseX, mouseY) ? 0xfffff8de : 0xAAFFFFFF);
+        graphics.drawString(Minecraft.getInstance().font, okayText,
+                okayButtonAlignCenter, buttonSpacingGap,
+                okayButtonBounds.contains(mouseX, mouseY) ? 0xfffff8de : 0xAAFFFFFF);
         graphics.pose().popPose();
         graphics.pose().popPose();
     }
     
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if (this.visible && button == 0 && buttonBounds.contains(mouseX, mouseY)) {
+        if ((this.visible && button == 0) && (okayButtonBounds.contains(mouseX, mouseY) || doNotShowButtonBounds.contains(mouseX, mouseY))) {
             dirty = false;
             this.visible = false;
+            if (doNotShowButtonBounds.contains(mouseX, mouseY)) {
+                ConfigObject.getInstance().setDoesPartialRecipesWarning(false);
+            }
             Widgets.produceClickSound();
             return true;
         }

--- a/runtime/src/main/resources/assets/roughlyenoughitems/lang/en_us.json
+++ b/runtime/src/main/resources/assets/roughlyenoughitems/lang/en_us.json
@@ -24,6 +24,7 @@
   "text.rei.recipes.not.full.title": "Partial Recipes Data Warning",
   "text.rei.recipes.not.full.desc": "REI does not have access to all recipes data!\nHere's what you can do:\n• If you are on a vanilla server and have operator permissions, running %s will unlock some recipes.\n• If you are on a modded server, ask the server owner to install REI on the server.",
   "text.rei.recipes.not.full.desc.command": "/recipe give @p *",
+  "text.rei.recipes.not.full.button.do_not_show_again": "Do not show again",
   "text.rei.recipes.not.full.button.okay": "Okay, I understand!",
   "text.rei.config.menu.dark_theme": "Dark Theme",
   "text.rei.config.menu.reduced_motion": "Reduced Motion",

--- a/runtime/src/main/resources/assets/roughlyenoughitems/lang/en_us.json
+++ b/runtime/src/main/resources/assets/roughlyenoughitems/lang/en_us.json
@@ -279,6 +279,8 @@
   "config.rei.options.appearance.append_mod_names.desc": "Appends the containing namespace for entries. The appended line will be in italisised light blue.",
   "config.rei.options.appearance.append_favorites_hint": "Append Favorites Hint",
   "config.rei.options.appearance.append_favorites_hint.desc": "Shows a hint on how to favorite an entry, or a recipe.",
+  "config.rei.options.appearance.partial_recipes_warning": "Partial Recipes Warning",
+  "config.rei.options.appearance.partial_recipes_warning.desc": "Whether to show partial recipes warning or not.",
   "config.rei.options.groups.appearance.advanced": "Advanced",
   "config.rei.options.appearance.rainbow": "Rainbow o(〒﹏〒)o",
   "config.rei.options.groups.input.keybinds": "Keybinds",

--- a/runtime/src/main/resources/assets/roughlyenoughitems/lang/zh_cn.json
+++ b/runtime/src/main/resources/assets/roughlyenoughitems/lang/zh_cn.json
@@ -273,6 +273,8 @@
   "config.rei.options.appearance.append_mod_names.desc": "将在提示框中添加其模块名称。该名称将以浅蓝色的斜体呈现。",
   "config.rei.options.appearance.append_favorites_hint": "附加收藏夹提示：",
   "config.rei.options.appearance.append_favorites_hint.desc": "将在提示框中添加将项目或配方添加至收藏夹的提示。",
+  "config.rei.options.appearance.partial_recipes_warning": "缺少配方警告",
+  "config.rei.options.appearance.partial_recipes_warning.desc": "决定是否显示缺少配方警告。",
   "config.rei.options.groups.appearance.advanced": "高级",
   "config.rei.options.appearance.rainbow": "彩虹 o(〒﹏〒)o",
   "config.rei.options.groups.input.keybinds": "按键绑定",


### PR DESCRIPTION
**Added the `Do not show again` button which sets the REI config option switch implemented by @MoonWX on PR #1881 to `false` when clicked.**

![recipe-warning](https://github.com/user-attachments/assets/3a80f47c-417b-4938-93f3-632f75bc270a)


Clicking `Do not show again` sets the following option to `false` (disabled):
![config-option-after-click](https://github.com/user-attachments/assets/2cfe872f-2e91-400b-b963-2f7319755399)


I tested the GUI on varying window sizes to make sure alignment is perfect.

**Please note**: the "clickable" area of these buttons **both extend to the ends of the box**. In other words, you can click the buttons on the left or right sides, beyond the text.

If that behavior is not desired, let me know. It was the only way I could have the buttons reliably be clicked in all window sizes and widths.


Thanks @MoonWX for implementing the config option in #1881 ! I subsequently felt inspired to do this piece.