### PR TITLE
Fix ImportantWarningsWidget blocking mouse clicks when hidden

### DIFF
--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/hints/ImportantWarningsWidget.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/hints/ImportantWarningsWidget.java
@@ -129,4 +129,10 @@ public class ImportantWarningsWidget extends WidgetWithBounds {
     public List<? extends GuiEventListener> children() {
         return List.of();
     }
+
+    @Override
+    public boolean containsMouse(double mouseX, double mouseY) {
+        if (!this.visible) return false;
+        return super.containsMouse(mouseX, mouseY);
+    }
 }


### PR DESCRIPTION
The Recipe Warnings widget currently blocks clicks while it is not visible, which interferes with the widgets/elements that other mods place.