### PR TITLE
build: add jitpack meta file

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+jdk:
+  - openjdk21
+install:
+  - ./gradlew publishToMavenLocal
+


### PR DESCRIPTION
Adds a jitpack.yml file that allows compiling against any commit while they are still in beta. This would help me build plugins for 1.21.6 while that is still in development, so this is against the 1.21.6 branch, but this is not really a 1.21.6 specific change.