### PR TITLE
Fix "Plugins are reloading!" text not showing on 1.21.6+

### DIFF
--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/screen/ConfigReloadingScreen.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/screen/ConfigReloadingScreen.java
@@ -29,6 +29,7 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
+import net.minecraft.util.CommonColors;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 
@@ -92,10 +93,10 @@ public class ConfigReloadingScreen extends Screen {
         int o = this.isFocused() ? -1 : -6250336;
         graphics.fill(k + 1, l, k + m, l + n, -16777216);
         graphics.renderOutline(k, l, m, n, o);
-        graphics.drawCenteredString(this.font, title, this.width / 2, l + 12, 0xffffff);
-        graphics.drawCenteredString(this.font, text, this.width / 2, l + 12 + 9, 0x808080);
+        graphics.drawCenteredString(this.font, title, this.width / 2, l + 12, CommonColors.WHITE);
+        graphics.drawCenteredString(this.font, text, this.width / 2, l + 12 + 9, 0xFF808080);
         if (subtitle != null) {
-            graphics.drawCenteredString(this.font, subtitle, this.width / 2, l + 12 + 9 + 9, 0x808080);
+            graphics.drawCenteredString(this.font, subtitle, this.width / 2, l + 12 + 9 + 9, 0xFF808080);
         }
     }
 }


### PR DESCRIPTION
The color integers were missing the alpha channel

before:
<img width="385" height="212" alt="image" src="https://github.com/user-attachments/assets/9ee4f489-9828-4037-8583-ca98860c8232" />

after:
<img width="357" height="139" alt="image" src="https://github.com/user-attachments/assets/a3bb380d-6421-49cc-88c2-e0e6793b0a50" />
