### PR TITLE
 build: add jitpack meta file 

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+jdk:
+  - openjdk21
+install:
+  - ./gradlew publishToMavenLocal
+


### PR DESCRIPTION
Allows downloading git artifacts via jitpack for snapshot development.

see https://jitpack.io/com/github/nea89o/roughlyenoughitems/jitpack-a100bdeeb1-1/build.log for an example build output. this would be really nice to work with betas.