### PR TITLE
Don't update dragging stack if a widget consumes the mouse click

### DIFF
--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/ScreenOverlayImpl.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/ScreenOverlayImpl.java
@@ -515,9 +515,6 @@ public abstract class ScreenOverlayImpl extends ScreenOverlay {
         if (!visible) {
             return false;
         }
-        if (draggingStack != null) {
-            draggingStack.mouseClicked(event, doubleClick);
-        }
         for (GuiEventListener element : widgets) {
             if (element != configButton && element != menuHolder.widget() && element != hintsWidget && element != draggingStack && element.mouseClicked(event, doubleClick)) {
                 this.setFocused(element);
@@ -527,6 +524,9 @@ public abstract class ScreenOverlayImpl extends ScreenOverlay {
                     REIRuntimeImpl.getSearchField().setFocused(false);
                 return true;
             }
+        }
+        if (draggingStack != null) {
+            draggingStack.mouseClicked(event, doubleClick);
         }
         if (ConfigObject.getInstance().getFocusSearchFieldKeybind().matchesMouse(event.button())) {
             REIRuntimeImpl.getSearchField().setFocused(true);


### PR DESCRIPTION
When `ScreenOverlayImpl` handles a mouse click, the dragging stack receives the event before any widgets. This means the user may start dragging some `DraggableComponent` even if the mouse click was handled by a widget.

This PR moves the mouse click handling for the dragging stack to after the screen's widgets. If a widget handles the click, the dragging stack will not receive the mouse click event.

### Example use case

For my mod Rechiseled, I am trying to add a scrollbar widget as part of a recipe display in `DisplayCategory#setupDisplay`. Currently, as any displays are wrapped in a `DraggableComponent`, when the user starts to drag the scrollbar, it starts dragging the `DraggableComponent` for the display as well.
With this PR, the scrollbar would consume the mouse click and the dragging stack would not start dragging the `DraggableComponent` for the display.

![Animation](https://github.com/user-attachments/assets/92a66dc6-585b-4026-af2a-6597a1a86458)
