### PR TITLE
Fix erroneous tooltips from out of sight DisplayEntry

### DIFF
--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/favorites/history/DisplayEntry.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/gui/widget/favorites/history/DisplayEntry.java
@@ -167,7 +167,7 @@ public class DisplayEntry extends WidgetWithBounds {
             reachedStable = true;
         }
         
-        if (stable && (bounds.getMaxX() + xOffset < parent.getBounds().x || bounds.x + xOffset > parent.getBounds().getMaxX())) {
+        if (stable && (bounds.getMaxX() + xOffset() < parent.getBounds().x || bounds.x + xOffset() > parent.getBounds().getMaxX())) {
             return;
         }
         


### PR DESCRIPTION
If there are multiple display entries, then the tooltips of out of sight display entries can sometimes be seen.

https://github.com/user-attachments/assets/ac7448ae-3d69-4433-9d36-d530266648c0

Using the value of `xOffset()` instead of `xOffset` seems to be all that is necessary to reach the return and prevent these erroneous tooltips.

I noticed this bug in 1.21.1, so it looks like it has been around for a little while.