### PR TITLE
fix: mark TextField isFocused() method as @Unique, fixing #1818

### DIFF
--- a/api/src/main/java/me/shedaniel/rei/api/client/gui/widgets/TextField.java
+++ b/api/src/main/java/me/shedaniel/rei/api/client/gui/widgets/TextField.java
@@ -54,6 +54,7 @@ public interface TextField {
     
     void setNotEditableColor(int notEditableColor);
     
+    @Unique
     boolean isFocused();
     
     void setFocused(boolean focused);


### PR DESCRIPTION
TextField.isFocused() gets accidentally remapped by Fabric Loom to method_25370 (the intermediary name of AbstractWidget.isFocused()), making it unusable through the public API. Tracked in #1818.

Annotate isFocused() in the TextField interface with @Unique to tell Loom this is not a Minecraft method and should not be remapped.

It was breaking a large variety of mods, hope you can accept this PR soon :)
(made my PR to the "last update" branch, idk which one is the right one)