### PR TITLE
Made local fallback load recipes for in-game unlocked recipes too on dedicated servers (fixes #2063)

### DIFF
--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/registry/display/ClientRecipeFallback.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/registry/display/ClientRecipeFallback.java
@@ -181,7 +181,7 @@ public final class ClientRecipeFallback {
             ensureLoaded();
             return;
         }
-        registry.addFallbackRecipes(entries, serverProvidedIds);
+        registry.addFallbackRecipes(entries, Set.of());
     }
 
     @Nullable

--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/registry/display/DisplayRegistryImpl.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/registry/display/DisplayRegistryImpl.java
@@ -52,6 +52,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public class DisplayRegistryImpl extends AbstractDisplayRegistry<REIClientPlugin, DisplayRegistryImpl.ClientDisplaysHolder> implements DisplayRegistry, DisplayConsumerImpl, DisplayGeneratorsRegistryImpl {
     public static final Object SYNCED = new Object();
@@ -192,6 +193,7 @@ public class DisplayRegistryImpl extends AbstractDisplayRegistry<REIClientPlugin
     }
     
     public void addRecipes(List<RecipeDisplayEntry> entries) {
+        removeFallbackRecipes(entries.stream().map(RecipeDisplayEntry::id).collect(Collectors.toSet()));
         Stopwatch stopwatch = Stopwatch.createStarted();
         int lastSize = size();
         if (!fillers().isEmpty()) {


### PR DESCRIPTION
# Summary

Fixes #2063.

> [!NOTE]
> The fix specified in this PR was found using AI, which was used to quickly navigate the codebase and narrow down the fix itself. The end result, however, has been tested by me on two separate devices running identical configurations (see [Testing](#testing)).

> [!NOTE]
> The sections below are copied from the original issue and the comment I posted on that issue regarding this fix.

## (Brief) Issue description

REI shows the crafting recipes for all vanilla items on an online Minecraft server until those items are unlocked in-game. Then, only that item's icon remains in the REI list of items, clicking it does not bring up the crafting recipe like it used to.

## Fix

When the fallback is loaded, I made it so that it doesn't check any `excludedIds` that were sent from the server and just loads the local fallback recipes for each item (by passing in `Set.of()` as `excludedIds` to `registry.addFallbackRecipes`).

Then, to avoid duplication with any server-sent recipes, I de-duplicated them in `addRecipes` by invoking `removeFallbackRecipes` before anything else gets done.

## Testing

Ran a dedicated vanilla Paper 26.2 (Experimental, build 48) server. Joined game with Fabric 26.2 client, tested against recipe for `minecraft:yellow_wool`. REI menu showed the crafting recipe. Unlocked it via `/recipe give @s minecraft:yellow_wool`. Confirmed it still shows up in the REI menu. Disconnected and reconnected to the server. REI still showed the recipe, as intended. Re-ran the test with `minecraft:oak_planks` too. That worked as well.

## Limitations

This fixes the issue in vanilla servers without an REI component installed (only present client-side). However, any servers that do not have an REI component installed but alter recipes through mods/datapacks will still be plagued by the same issue of disappearing recipes once reloaded after the server sends through a packet for them. The real fix for that would move towards caching the server's sent packets and replaying them in `endReload`. This, however, is a change [that I did not attempt].