### PR TITLE
Fix pinyin-to-bopomofo conversion in the bopomofo input method

### DIFF
--- a/runtime/src/main/java/me/shedaniel/rei/impl/client/search/method/unihan/BomopofoInputMethod.java
+++ b/runtime/src/main/java/me/shedaniel/rei/impl/client/search/method/unihan/BomopofoInputMethod.java
@@ -23,7 +23,8 @@
 
 package me.shedaniel.rei.impl.client.search.method.unihan;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntList;
 import me.shedaniel.rei.api.client.favorites.FavoriteMenuEntry;
 import net.minecraft.network.chat.Component;
@@ -31,6 +32,7 @@ import net.minecraft.network.chat.Component;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -58,22 +60,72 @@ import java.util.stream.Stream;
  * SOFTWARE.
  */
 public class BomopofoInputMethod extends PinyinInputMethod {
-    private static final Map<IntList, IntList> CONVERSION = Stream.of(new String[][]{
-            {"", ""}, {"0", ""}, {"1", " "}, {"2", "6"}, {"3", "3"},
-            {"4", "4"}, {"a", "8"}, {"ai", "9"}, {"an", "0"}, {"ang", ";"},
-            {"ao", "l"}, {"b", "1"}, {"c", "h"}, {"ch", "t"}, {"d", "2"},
-            {"e", "k"}, {"ei", "o"}, {"en", "p"}, {"eng", "/"}, {"er", "-"},
-            {"f", "z"}, {"g", "e"}, {"h", "c"}, {"i", "u"}, {"ia", "u8"},
-            {"ian", "u0"}, {"iang", "u;"}, {"iao", "ul"}, {"ie", "u,"}, {"in", "up"},
-            {"ing", "u/"}, {"iong", "m/"}, {"iu", "u."}, {"j", "r"}, {"k", "d"},
-            {"l", "x"}, {"m", "a"}, {"n", "s"}, {"o", "i"}, {"ong", "j/"},
-            {"ou", "."}, {"p", "q"}, {"q", "f"}, {"r", "b"}, {"s", "n"},
-            {"sh", "g"}, {"t", "w"}, {"u", "j"}, {"ua", "j8"}, {"uai", "j9"},
-            {"uan", "j0"}, {"uang", "j;"}, {"uen", "mp"}, {"ueng", "j/"}, {"ui", "jo"},
-            {"un", "jp"}, {"uo", "ji"}, {"v", "m"}, {"van", "m0"}, {"vang", "m;"},
-            {"ve", "m,"}, {"vn", "mp"}, {"w", "j"}, {"x", "v"}, {"y", "u"},
-            {"z", "y"}, {"zh", "5"},
-    }).collect(Collectors.toMap(d -> IntList.of(d[0].codePoints().toArray()), d -> IntList.of(d[1].trim().codePoints().toArray())));
+    /**
+     * Pinyin initials, as their key positions on the 大千 (standard zhuyin) keyboard.
+     */
+    private static final Map<String, String> INITIALS = table(new String[][]{
+            {"b", "1"}, {"p", "q"}, {"m", "a"}, {"f", "z"},
+            {"d", "2"}, {"t", "w"}, {"n", "s"}, {"l", "x"},
+            {"g", "e"}, {"k", "d"}, {"h", "c"},
+            {"j", "r"}, {"q", "f"}, {"x", "v"},
+            {"zh", "5"}, {"ch", "t"}, {"sh", "g"}, {"r", "b"},
+            {"z", "y"}, {"c", "h"}, {"s", "n"},
+    });
+    
+    /**
+     * Pinyin finals, as their key positions on the 大千 keyboard. Keyed by the normalised
+     * spelling produced by {@link #split(String)}: {@code ü} is written {@code v}, and the
+     * finals that pinyin abbreviates are listed under both spellings.
+     */
+    private static final Map<String, String> FINALS = table(new String[][]{
+            {"", ""},
+            {"a", "8"}, {"o", "i"}, {"e", "k"}, {"ê", ","},
+            {"ai", "9"}, {"ei", "o"}, {"ao", "l"}, {"ou", "."},
+            {"an", "0"}, {"en", "p"}, {"ang", ";"}, {"eng", "/"}, {"er", "-"},
+            {"i", "u"}, {"ia", "u8"}, {"io", "ui"}, {"ie", "u,"}, {"iai", "u9"},
+            {"iao", "ul"}, {"iu", "u."}, {"iou", "u."}, {"ian", "u0"}, {"in", "up"},
+            {"iang", "u;"}, {"ing", "u/"}, {"iong", "m/"},
+            {"u", "j"}, {"ua", "j8"}, {"uo", "ji"}, {"uai", "j9"}, {"ui", "jo"},
+            {"uei", "jo"}, {"uan", "j0"}, {"un", "jp"}, {"uen", "jp"}, {"uang", "j;"},
+            {"ong", "j/"}, {"ueng", "j/"}, {"uong", "j/"},
+            {"v", "m"}, {"ve", "m,"}, {"van", "m0"}, {"vn", "mp"},
+    });
+    
+    /**
+     * Syllables that are not built out of an initial and a final: the syllabic nasals.
+     */
+    private static final Map<String, String> SYLLABIC = table(new String[][]{
+            {"m", "a"}, {"n", "p"}, {"ng", "/"}, {"hm", "ca"}, {"hng", "c/"},
+    });
+    
+    /**
+     * The initials that form a whole syllable on their own, where the vowel pinyin writes
+     * is the empty rime rather than ㄧ.
+     */
+    private static final Set<String> EMPTY_RIME = Set.of("zh", "ch", "sh", "r", "z", "c", "s");
+    
+    /**
+     * Tone keys on the 大千 keyboard, indexed by tone number. The first tone is unmarked in
+     * zhuyin and is typed with a space, which is not usable inside a search filter.
+     */
+    private static final String[] TONES = {"7", "", "6", "3", "4"};
+    
+    /**
+     * Tone marks that {@link PinyinInputMethod#toneMap} does not carry, because they only
+     * ever appear on the syllabic nasals above.
+     */
+    private static final Int2ObjectMap<ToneEntry> NASAL_TONES = new Int2ObjectOpenHashMap<>();
+    
+    static {
+        NASAL_TONES.put('ḿ', new ToneEntry('m', 2));
+        NASAL_TONES.put('ń', new ToneEntry('n', 2));
+        NASAL_TONES.put('ň', new ToneEntry('n', 3));
+        NASAL_TONES.put('ǹ', new ToneEntry('n', 4));
+    }
+    
+    private static Map<String, String> table(String[][] entries) {
+        return Stream.of(entries).collect(Collectors.toUnmodifiableMap(entry -> entry[0], entry -> entry[1]));
+    }
     
     public BomopofoInputMethod(UniHanManager manager) {
         super(manager);
@@ -96,52 +148,80 @@ public class BomopofoInputMethod extends PinyinInputMethod {
     
     @Override
     protected List<ExpendedChar> asExpendedChars(String string) {
-        IntList codepoints = new IntArrayList(string.length() + 1);
-        int[] tone = {-1};
-        string.codePoints().forEach(codepoint -> {
-            if (codepoint == 'ü') {
-                codepoints.add('v');
-                return;
+        StringBuilder builder = new StringBuilder(string.length());
+        int tone = 0;
+        for (int i = 0; i < string.length(); i++) {
+            char c = string.charAt(i);
+            if (c == 'ü') {
+                builder.append('v');
+                continue;
             }
-            ToneEntry toneEntry = toneMap.get(codepoint);
+            ToneEntry toneEntry = toneMap.get(c);
+            if (toneEntry == null) toneEntry = NASAL_TONES.get(c);
             if (toneEntry == null) {
-                codepoints.add(codepoint);
+                builder.append(c);
             } else {
-                codepoints.add(toneEntry.codepoint());
-                tone[0] = toneEntry.tone();
+                builder.append((char) toneEntry.codepoint());
+                tone = toneEntry.tone();
             }
-        });
-        if (tone[0] != -1) {
-            codepoints.add(Character.forDigit(tone[0], 10));
         }
-        List<IntList> phonemes = standard(codepoints).stream().map(str -> CONVERSION.getOrDefault(str, str)).toList();
+        String[] keys = split(builder.toString());
+        if (keys == null) return List.of();
+        List<IntList> phonemes = new ArrayList<>(3);
+        addPhoneme(phonemes, keys[0]);
+        addPhoneme(phonemes, keys[1]);
+        addPhoneme(phonemes, TONES[tone]);
         return List.of(new ExpendedChar(phonemes));
     }
     
-    private static List<IntList> standard(IntList s) {
-        List<IntList> ret = new ArrayList<>();
-        int cursor = 0;
-        
-        // initial
-        if (hasInitial(s)) {
-            cursor = s.size() > 2 && s.getInt(1) == 'h' ? 2 : 1;
-            ret.add(s.subList(0, cursor));
-        }
-        
-        // final
-        if (s.size() != cursor + 1 && s.size() - 1 > cursor) {
-            ret.add(s.subList(cursor, s.size() - 1));
-        }
-        
-        // tone
-        if (s.size() >= 1) {
-            ret.add(s.subList(s.size() - 1, s.size()));
-        }
-        
-        return ret;
+    private static void addPhoneme(List<IntList> phonemes, String keys) {
+        if (!keys.isEmpty()) phonemes.add(IntList.of(keys.codePoints().toArray()));
     }
     
-    private static boolean hasInitial(IntList s) {
-        return Stream.of('a', 'e', 'i', 'o', 'u', 'v').noneMatch(i -> s.getInt(0) == i);
+    /**
+     * Splits a toneless pinyin syllable into the keys of its zhuyin initial and its zhuyin
+     * final, or returns {@code null} if it is not a syllable this mapping knows.
+     */
+    private static String[] split(String syllable) {
+        if (syllable.isEmpty()) return null;
+        String whole = SYLLABIC.get(syllable);
+        if (whole != null) return new String[]{whole, ""};
+        
+        // ㄧㄨㄩ are spelled y- and w- at the start of a syllable, where they are the medial
+        // and not an initial of their own.
+        String s = syllable;
+        if (s.charAt(0) == 'y') {
+            String rest = s.substring(1);
+            if (rest.startsWith("u")) s = "v" + rest.substring(1);
+            else if (rest.isEmpty()) s = "i";
+            else if (rest.charAt(0) == 'i') s = rest;
+            else s = "i" + rest;
+        } else if (s.charAt(0) == 'w') {
+            String rest = s.substring(1);
+            s = rest.startsWith("u") ? rest : "u" + rest;
+        }
+        
+        String initial = "";
+        if (s.length() > 1 && s.charAt(1) == 'h' && "zcs".indexOf(s.charAt(0)) >= 0) {
+            initial = s.substring(0, 2);
+            s = s.substring(2);
+        } else if (INITIALS.containsKey(s.substring(0, 1))) {
+            initial = s.substring(0, 1);
+            s = s.substring(1);
+        }
+        
+        // ㄐㄑㄒ are never followed by ㄨ, so pinyin drops the diaeresis of ü after them.
+        if (s.startsWith("u") && ("j".equals(initial) || "q".equals(initial) || "x".equals(initial))) {
+            s = "v" + s.substring(1);
+        }
+        
+        // ㄓㄔㄕㄖㄗㄘㄙ are whole syllables on their own; pinyin writes that empty rime as i.
+        if (s.equals("i") && EMPTY_RIME.contains(initial)) {
+            s = "";
+        }
+        
+        String finals = FINALS.get(s);
+        if (finals == null) return null;
+        return new String[]{initial.isEmpty() ? "" : INITIALS.get(initial), finals};
     }
 }

--- a/runtime/src/test/java/InputMethodTest.java
+++ b/runtime/src/test/java/InputMethodTest.java
@@ -24,6 +24,7 @@
 import it.unimi.dsi.fastutil.ints.IntList;
 import me.shedaniel.rei.impl.Internals;
 import me.shedaniel.rei.impl.client.search.argument.InputMethodMatcher;
+import me.shedaniel.rei.impl.client.search.method.unihan.BomopofoInputMethod;
 import me.shedaniel.rei.impl.client.search.method.unihan.PinyinInputMethod;
 import me.shedaniel.rei.impl.client.search.method.unihan.UniHanManager;
 import me.shedaniel.rei.impl.common.InternalLogger;
@@ -62,16 +63,97 @@ public class InputMethodTest {
     static Path tempDir;
     
     static PinyinInputMethod pinyinInputMethod;
+    static BomopofoInputMethod bomopofoInputMethod;
     
     @BeforeAll
     static void setup() {
         Internals.attachInstanceSupplier(LOGGER, "logger");
         
         UniHanManager manager = new UniHanManager(tempDir.resolve("unihan.zip"));
-        pinyinInputMethod = new PinyinInputMethod(manager);
+        pinyinInputMethod = new TestPinyinInputMethod(manager);
+        bomopofoInputMethod = new TestBomopofoInputMethod(manager);
         ExecutorService service = Executors.newSingleThreadExecutor();
         pinyinInputMethod.prepare(service).join();
+        bomopofoInputMethod.prepare(service).join();
         service.shutdown();
+    }
+    
+    /**
+     * The fuzzy matching options live in the game's config folder, which does not exist
+     * outside of a running game; the tests run with every option left at its default.
+     */
+    static class TestPinyinInputMethod extends PinyinInputMethod {
+        TestPinyinInputMethod(UniHanManager manager) {
+            super(manager);
+        }
+        
+        @Override
+        protected void read() {}
+        
+        @Override
+        protected void write() {}
+    }
+    
+    static class TestBomopofoInputMethod extends BomopofoInputMethod {
+        TestBomopofoInputMethod(UniHanManager manager) {
+            super(manager);
+        }
+        
+        @Override
+        protected void read() {}
+        
+        @Override
+        protected void write() {}
+    }
+    
+    @Test
+    void testBopomofo() {
+        // Sequences are 大千 (standard zhuyin) keyboard positions: ㄕ is g, ㄨ is j, ˋ is 4.
+        
+        // ㄓㄔㄕㄖㄗㄘㄙ are whole syllables on their own; the i of shi/zhi/zi is the empty
+        // rime and not ㄧ.
+        assertTrue(bopomofoContains("室", "g4"));
+        assertTrue(bopomofoContains("室", "g"));
+        assertFalse(bopomofoContains("室", "gu4"));
+        assertTrue(bopomofoContains("知", "5"));
+        assertTrue(bopomofoContains("字", "y4"));
+        
+        // ㄐㄑㄒ are never followed by ㄨ: the u of ju/qu/xu is ㄩ.
+        assertTrue(bopomofoContains("居", "rm"));
+        assertFalse(bopomofoContains("居", "rj"));
+        assertTrue(bopomofoContains("窮", "fm/6"));
+        
+        // y and w are not initials, they spell a syllable-initial ㄧ/ㄨ/ㄩ.
+        assertTrue(bopomofoContains("一", "u"));
+        assertFalse(bopomofoContains("一", "uu"));
+        assertTrue(bopomofoContains("語", "m3"));
+        assertTrue(bopomofoContains("雲", "mp6"));
+        assertTrue(bopomofoContains("永", "m/3"));
+        assertTrue(bopomofoContains("翁", "j/"));
+        assertTrue(bopomofoContains("五", "j3"));
+        
+        // ㄩ finals.
+        assertTrue(bopomofoContains("雪", "vm,3"));
+        assertTrue(bopomofoContains("雪", "vm"));
+        assertFalse(bopomofoContains("雪", "vue3"));
+        assertTrue(bopomofoContains("月", "m,4"));
+        assertTrue(bopomofoContains("略", "xm,4"));
+        assertTrue(bopomofoContains("綠", "xm4"));
+        
+        // Finals that pinyin abbreviates, and the neutral tone.
+        assertTrue(bopomofoContains("流", "xu.6"));
+        assertTrue(bopomofoContains("水", "gjo3"));
+        assertTrue(bopomofoContains("文", "jp6"));
+        assertTrue(bopomofoContains("的", "2k7"));
+        assertTrue(bopomofoContains("的", "2k"));
+        assertTrue(bopomofoContains("兒", "-6"));
+        
+        // Whole strings, both fully typed and with syllables left unfinished.
+        assertTrue(bopomofoContains("測試文本", "hk4g4jp61p3"));
+        assertTrue(bopomofoContains("測試文本", "hgjp1p"));
+        assertTrue(bopomofoContains("洗礦場", "vu3dj;4t;3"));
+        assertTrue(bopomofoContains("合金爐", "ckrupxj"));
+        assertFalse(bopomofoContains("測試文本", "hk6g4jp61p3"));
     }
     
     void testPinyin() {
@@ -95,5 +177,9 @@ public class InputMethodTest {
     
     boolean pinyinContains(String input, String substr) {
         return InputMethodMatcher.contains(pinyinInputMethod, IntList.of(input.codePoints().toArray()), IntList.of(substr.codePoints().toArray()));
+    }
+    
+    boolean bopomofoContains(String input, String substr) {
+        return InputMethodMatcher.contains(bomopofoInputMethod, IntList.of(input.codePoints().toArray()), IntList.of(substr.codePoints().toArray()));
     }
 }


### PR DESCRIPTION
# Fix pinyin-to-bopomofo conversion in the bopomofo input method

## Problem

The bopomofo input method takes 大千 (standard zhuyin) keyboard sequences. It builds them
from Unihan's `kMandarin` field, which is pinyin, and gets it wrong for about one character
in six.

`asExpendedChars` strips the tone mark, `standard()` cuts the syllable into initial, final
and tone, and each piece is looked up in one flat `CONVERSION` table. That table maps
pinyin `i` to ㄧ always, and `standard()` has no rules for the places where pinyin spelling
and zhuyin phonology differ:

| what breaks | example | produced | correct |
|---|---|---|---|
| empty rime read as ㄧ | 室 shì | `gu4` ㄕㄧˋ | `g4` ㄕˋ |
| ü after ㄐㄑㄒ read as ㄨ | 居 jū | `rj` ㄐㄨ | `rm` ㄐㄩ |
| y/w read as initials | 一 yī | `uu` ㄧㄧ | `u` ㄧ |
| ü finals missing from the table | 雪 xuě | `vue3` ㄒㄧㄍˇ | `vm,3` ㄒㄩㄝˇ |

In the last row `ue` is not in the table, so `getOrDefault` returns the key itself and the
`e` is then read as a key position, which is ㄍ.

`CONVERSION` also maps `uen` to `mp` (ㄩㄣ) where ㄨㄣ is `jp`. `kMandarin` never spells a
final `uen`, so that entry never runs.

## Fix

`standard()` and `CONVERSION` are replaced by an explicit initial/final split with the
missing rules:

- `y-` and `w-` become the medial ㄧ/ㄨ/ㄩ they stand for.
- `u` after `j`/`q`/`x` is ü.
- `i` after `zh ch sh r z c s` is the empty rime, so the initial is the whole syllable.
- The finals table covers the ㄩ series, and both spellings of the finals pinyin shortens
  (`iu`/`iou`, `ui`/`uei`, `un`/`uen`).
- Syllabic nasals (`m` 呣, `n` 嗯, `ng`, `hm` 噷) have no initial/final split and are mapped
  directly. Their tone marks `ḿ ń ň ǹ` are not in `PinyinInputMethod`'s tone map, so they
  are handled here.

The matcher still sees initial, final, tone, so prefix matching is unchanged.

One change outside the bug: the 153 characters whose `kMandarin` has no tone mark (的 de,
了 le, 們 men, 吧 ba …) now emit the neutral tone ˙ = `7` instead of nothing. This only adds
matches — `2k` still finds 的, and `2k7` now does too.

## Check

Every `kMandarin` reading in the Unihan file the mod downloads was converted with the old
and the new code, then compared against pypinyin's `Style.BOPOMOFO` output mapped onto the
大千 layout. 41,419 characters, 41,471 readings, 1,465 syllables.

| | wrong syllables | wrong readings |
|---|---|---|
| before | 214 | 6,503 (15.68%) |
| after | 2 | 2 (0.00%) |

The worst syllables before were yì (458 characters), zhì (293), yù (276), jué (206),
yú (198), yí (191), shì (152).

The two left over are pypinyin's own quirks: it rewrites a syllabic `m` (呣) to `mu`, and
its `^n(\d)$` → ㄣ rule runs before the rule that adds a default tone, so a toneless `n`
(𧗈) falls through to ㄋ.

## Tests

`InputMethodTest` could not run outside the game. `PinyinInputMethod`'s constructor reads
the fuzzy matching options from `Platform.getConfigFolder()`, which asserts when no
platform is loaded, which is why `testPinyin` never had `@Test`. Both input methods are now
built through small subclasses that stub the config read and write, and `testBopomofo`
covers the four rows above plus whole-string matching.

`testPinyin` is still not annotated. It runs now, but `pinyinContains("漢語", "hayu")` fails:
the matcher only allows a partial match on the last phoneme of the query, so a syllable
cannot be cut inside its final in the middle of a string. That looks like a stale
expectation, not something this PR should change.
